### PR TITLE
feat: isolate custom interceptor interface by method

### DIFF
--- a/spec/pagination/read-many.request.interceptor.ts
+++ b/spec/pagination/read-many.request.interceptor.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { Request } from 'express';
 
-import { CustomRequestInterceptor, CustomRequestOptions } from '../../src';
+import { CustomRequestInterceptor, CustomReadManyRequestOptions } from '../../src';
 
 @Injectable()
 export class ReadManyRequestInterceptor extends CustomRequestInterceptor {
-    async overrideOptions(_req: Request): Promise<CustomRequestOptions> {
+    async overrideOptions(_req: Request): Promise<CustomReadManyRequestOptions> {
         return new Promise((resolve, _reject) => {
             resolve({
                 softDeleted: true,

--- a/spec/param-option/params.interceptor.ts
+++ b/spec/param-option/params.interceptor.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { Request } from 'express';
 
-import { CustomRequestInterceptor, CustomRequestOptions } from '../../src';
+import { CustomRequestInterceptor, CustomReadOneRequestOptions } from '../../src';
 
 @Injectable()
 export class ParamsInterceptor extends CustomRequestInterceptor {
-    async overrideOptions(req: Request): Promise<CustomRequestOptions> {
+    async overrideOptions(req: Request): Promise<CustomReadOneRequestOptions> {
         return new Promise((resolve, _reject) => {
             req.params = { name: req.params?.custom };
             resolve({});

--- a/spec/relation-entities/comment-relation.interceptor.ts
+++ b/spec/relation-entities/comment-relation.interceptor.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { Request } from 'express';
 
-import { CustomRequestInterceptor, CustomRequestOptions } from '../../src';
+import { CustomRequestInterceptor, CustomReadOneRequestOptions } from '../../src';
 
 @Injectable()
 export class CommentRelationInterceptor extends CustomRequestInterceptor {
-    async overrideOptions(req: Request): Promise<CustomRequestOptions> {
+    async overrideOptions(req: Request): Promise<CustomReadOneRequestOptions> {
         return new Promise((resolve, _reject) => {
             resolve({
                 relations: +req.params.id % 2 === 0 ? ['writer'] : [],

--- a/spec/request-interceptor/delete.request.interceptor.ts
+++ b/spec/request-interceptor/delete.request.interceptor.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { Request } from 'express';
 
-import { CustomRequestInterceptor, CustomRequestOptions } from '../../src';
+import { CustomRequestInterceptor, CustomDeleteRequestOptions } from '../../src';
 
 @Injectable()
 export class DeleteRequestInterceptor extends CustomRequestInterceptor {
-    async overrideOptions(req: Request): Promise<CustomRequestOptions> {
+    async overrideOptions(req: Request): Promise<CustomDeleteRequestOptions> {
         const softDeleted = +req.params.id > 2 ? undefined : false;
 
         return new Promise((resolve, _reject) => {

--- a/spec/request-interceptor/read-many.request.interceptor.ts
+++ b/spec/request-interceptor/read-many.request.interceptor.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { Request } from 'express';
 
-import { CustomRequestInterceptor, CustomRequestOptions } from '../../src';
+import { CustomRequestInterceptor, CustomReadManyRequestOptions } from '../../src';
 
 @Injectable()
 export class ReadManyRequestInterceptor extends CustomRequestInterceptor {
-    async overrideOptions(_req: Request): Promise<CustomRequestOptions> {
+    async overrideOptions(_req: Request): Promise<CustomReadManyRequestOptions> {
         return new Promise((resolve, _reject) => {
             resolve({
                 softDeleted: true,

--- a/spec/request-interceptor/read-one.request.interceptor.ts
+++ b/spec/request-interceptor/read-one.request.interceptor.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { Request } from 'express';
 
-import { CustomRequestInterceptor, CustomRequestOptions } from '../../src';
+import { CustomRequestInterceptor, CustomReadOneRequestOptions } from '../../src';
 
 @Injectable()
 export class ReadOneRequestInterceptor extends CustomRequestInterceptor {
-    async overrideOptions(req: Request): Promise<CustomRequestOptions> {
+    async overrideOptions(req: Request): Promise<CustomReadOneRequestOptions> {
         return new Promise((resolve, _reject) => {
             resolve({
                 fields: req.params.id === '1' ? ['name', 'createdAt'] : undefined,

--- a/src/lib/interceptor/custom-request.interceptor.ts
+++ b/src/lib/interceptor/custom-request.interceptor.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 
 import { Constants } from '../constants';
 
-export interface CustomRequestOptions {
+export interface CustomReadOneRequestOptions {
     fields?: string[];
     softDeleted?: boolean;
     relations?: string[];
@@ -29,8 +29,8 @@ export class CustomRequestInterceptor implements NestInterceptor {
 
     /**
      * @description
-     * [KR] 이 메소드를 오버라이드 하여, Request를 수정할 수 있습니다. 각 메소드에서 제공하는 Options을 통해 제어할 수 있습니다.
-     * [EN] override this method.
+     * [KR] 이 메소드를 오버라이드 하여, Request를 수정할 수 있습니다. 각 메소드에서 제공하는 Options을 통해 추가로 제어할 수 있습니다.
+     * [EN] modify request by override this method. If exists requestOption interface by method, Additional control.
      * @example
      * class MyAuthInterceptor extends CrudCustomRequestInterceptor {
      *   constructor(authService: AuthServer) {}
@@ -41,8 +41,11 @@ export class CustomRequestInterceptor implements NestInterceptor {
      *   }
      * }
      */
-    // TODO: 메소드 마다 CustomRequestOptions 인터페이스 분리하기
-    protected async overrideOptions(_req: Request): Promise<CustomRequestOptions | undefined> {
+    protected async overrideOptions(
+        _req: Request,
+    ): Promise<
+        CustomReadOneRequestOptions | CustomReadManyRequestOptions | CustomDeleteRequestOptions | CustomSearchRequestOptions | undefined
+    > {
         return;
     }
 }

--- a/src/lib/interceptor/delete-request.interceptor.ts
+++ b/src/lib/interceptor/delete-request.interceptor.ts
@@ -2,7 +2,7 @@ import { CallHandler, ExecutionContext, mixin, NestInterceptor } from '@nestjs/c
 import _ from 'lodash';
 import { Observable } from 'rxjs';
 
-import { CustomRequestOptions } from './custom-request.interceptor';
+import { CustomDeleteRequestOptions } from './custom-request.interceptor';
 import { RequestAbstractInterceptor } from '../abstract';
 import { Constants } from '../constants';
 import { CRUD_POLICY } from '../crud.policy';
@@ -14,10 +14,10 @@ export function DeleteRequestInterceptor(crudOptions: CrudOptions, factoryOption
         async intercept(context: ExecutionContext, next: CallHandler<unknown>): Promise<Observable<unknown>> {
             const req: Record<string, any> = context.switchToHttp().getRequest();
             const deleteOptions = crudOptions.routes?.[method] ?? {};
-            const customRequestOption: CustomRequestOptions = req[Constants.CUSTOM_REQUEST_OPTIONS];
+            const customDeleteRequestOptions: CustomDeleteRequestOptions = req[Constants.CUSTOM_REQUEST_OPTIONS];
 
-            const softDeleted = _.isBoolean(customRequestOption?.softDeleted)
-                ? customRequestOption.softDeleted
+            const softDeleted = _.isBoolean(customDeleteRequestOptions?.softDeleted)
+                ? customDeleteRequestOptions.softDeleted
                 : deleteOptions.softDelete ?? (CRUD_POLICY[method].default?.softDeleted as boolean);
 
             const params = await this.checkParams(crudOptions.entity, req.params, factoryOption.columns);

--- a/src/lib/interceptor/read-many-request.interceptor.ts
+++ b/src/lib/interceptor/read-many-request.interceptor.ts
@@ -5,7 +5,7 @@ import { Request } from 'express';
 import _ from 'lodash';
 import { Observable } from 'rxjs';
 
-import { CustomRequestOptions } from './custom-request.interceptor';
+import { CustomReadManyRequestOptions } from './custom-request.interceptor';
 import { RequestAbstractInterceptor } from '../abstract';
 import { Constants } from '../constants';
 import { CRUD_POLICY } from '../crud.policy';
@@ -20,7 +20,7 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
             const req: Record<string, any> = context.switchToHttp().getRequest<Request>();
             const readManyOptions = crudOptions.routes?.[method] ?? {};
 
-            const customRequestOption: CustomRequestOptions = req[Constants.CUSTOM_REQUEST_OPTIONS];
+            const customReadManyRequestOptions: CustomReadManyRequestOptions = req[Constants.CUSTOM_REQUEST_OPTIONS];
             const paginationType = (readManyOptions.paginationType ?? CRUD_POLICY[method].default?.paginationType) as PaginationType;
 
             const pagination = this.getPaginationRequest(paginationType, req.query);
@@ -35,8 +35,8 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
                 return this.validateQuery(req.query);
             })();
 
-            const softDeleted = _.isBoolean(customRequestOption?.softDeleted)
-                ? customRequestOption.softDeleted
+            const softDeleted = _.isBoolean(customReadManyRequestOptions?.softDeleted)
+                ? customReadManyRequestOptions.softDeleted
                 : crudOptions.routes?.[method]?.softDelete ?? (CRUD_POLICY[method].default?.softDelete as boolean);
 
             const crudReadManyRequest: CrudReadManyRequest<typeof crudOptions.entity> = {
@@ -45,7 +45,7 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
                 numberOfTake: readManyOptions.numberOfTake ?? (CRUD_POLICY[method].default?.numberOfTake as number),
                 query,
                 primaryKeys: factoryOption.primaryKeys ?? [],
-                relations: this.getRelations(customRequestOption),
+                relations: this.getRelations(customReadManyRequestOptions),
                 softDeleted,
             };
 
@@ -86,9 +86,9 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
             return transformed;
         }
 
-        getRelations(customRequestOption: CustomRequestOptions): string[] | undefined {
-            if (Array.isArray(customRequestOption?.relations)) {
-                return customRequestOption.relations;
+        getRelations(customReadManyRequestOptions: CustomReadManyRequestOptions): string[] | undefined {
+            if (Array.isArray(customReadManyRequestOptions?.relations)) {
+                return customReadManyRequestOptions.relations;
             }
             if (crudOptions.routes?.[method]?.relations === false) {
                 return [];

--- a/src/lib/interceptor/read-one-request.interceptor.ts
+++ b/src/lib/interceptor/read-one-request.interceptor.ts
@@ -6,7 +6,7 @@ import _ from 'lodash';
 import QueryString from 'qs';
 import { Observable } from 'rxjs';
 
-import { CustomRequestOptions } from './custom-request.interceptor';
+import { CustomReadOneRequestOptions } from './custom-request.interceptor';
 import { RequestAbstractInterceptor } from '../abstract';
 import { Constants } from '../constants';
 import { CRUD_POLICY } from '../crud.policy';
@@ -20,24 +20,24 @@ export function ReadOneRequestInterceptor(crudOptions: CrudOptions, factoryOptio
             const req: Record<string, any> = context.switchToHttp().getRequest<Request>();
             const readOneOptions = crudOptions.routes?.[method] ?? {};
 
-            const customRequestOption: CustomRequestOptions = req[Constants.CUSTOM_REQUEST_OPTIONS];
+            const customReadOneRequestOptions: CustomReadOneRequestOptions = req[Constants.CUSTOM_REQUEST_OPTIONS];
 
             const fieldsByRequest = this.checkFields(req.query?.fields);
 
-            const softDeleted = _.isBoolean(customRequestOption?.softDeleted)
-                ? customRequestOption.softDeleted
+            const softDeleted = _.isBoolean(customReadOneRequestOptions?.softDeleted)
+                ? customReadOneRequestOptions.softDeleted
                 : crudOptions.routes?.[method]?.softDelete ?? (CRUD_POLICY[method].default?.softDelete as boolean);
 
             const params = await this.checkParams(crudOptions.entity, req.params, factoryOption.columns);
 
             const crudReadOneRequest: CrudReadOneRequest<typeof crudOptions.entity> = {
                 params,
-                fields: this.getFields(customRequestOption?.fields, fieldsByRequest),
+                fields: this.getFields(customReadOneRequestOptions?.fields, fieldsByRequest),
                 softDeleted,
                 options: {
                     response: readOneOptions.response ?? CRUD_POLICY[method].response,
                 },
-                relations: this.getRelations(customRequestOption),
+                relations: this.getRelations(customReadOneRequestOptions),
             };
             req[Constants.CRUD_ROUTE_ARGS] = crudReadOneRequest;
 
@@ -72,9 +72,9 @@ export function ReadOneRequestInterceptor(crudOptions: CrudOptions, factoryOptio
             return requestFields.fields;
         }
 
-        getRelations(customRequestOption: CustomRequestOptions): string[] | undefined {
-            if (Array.isArray(customRequestOption?.relations)) {
-                return customRequestOption.relations;
+        getRelations(customReadOneRequestOptions: CustomReadOneRequestOptions): string[] | undefined {
+            if (Array.isArray(customReadOneRequestOptions?.relations)) {
+                return customReadOneRequestOptions.relations;
             }
             if (crudOptions.routes?.[method]?.relations === false) {
                 return [];


### PR DESCRIPTION
Isolate interface of custom interceptor by method.

This gives a clear picture of the capabilities that the custom interceptor provides.

---

Custom Interceptor가 제공하는 기능을 명확하게 할 수 있도록 메소드 별로 Interface를 분리합니다.
