### PR TITLE
fix: should be available swagger decorator

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -203,9 +203,9 @@ Decorator Option으로 route 마다 `swagger`를 비 활성화 할 수 있습니
 
 Decorator Option으로 route 마다 `decorators`를 정의할 수 있습니다.
 
-<a href="./spec/auth-guard/auth-guard.spec.ts">auth-guard.spec.ts</a>, <a href="./spec/custom-swagger-decorator/apply-api-extra-model.spec.ts">apply-api-extra-model.spec.ts</a>와 같이 method 별로 Decorator를 추가할 수 있습니다.
+<a href="./spec/auth-guard/auth-guard.spec.ts">auth-guard.spec.ts</a>, <a href="./spec/custom-swagger-decorator/apply-api-extra-model.spec.ts">apply-api-extra-model.spec.ts</a>, <a href="./spec/swagger-decorator">swagger-decorator</a>와 같이 method 별로 Decorator를 추가할 수 있습니다.
 
-Decorator의 기능이 CRUD에서 제공하는 기능일 경우 추가된 Decorator로 override 됩니다.
+Decorator의 기능이 CRUD에서 제공하는 기능과 중복될 경우 입력된 Decorator로 override 됩니다.
 
 ```
 @Crud({

--- a/README.md
+++ b/README.md
@@ -203,9 +203,9 @@ Decorator Option으로 route 마다 `swagger`를 비 활성화 할 수 있습니
 
 Decorator Option으로 route 마다 `decorators`를 정의할 수 있습니다.
 
-<a href="./spec/auth-guard/auth-guard.spec.ts">auth-guard.spec.ts</a>, <a href="./spec/custom-swagger-decorator/apply-api-extra-model.spec.ts">apply-api-extra-model.spec.ts</a>와 같이 method 별로 Decorator를 추가할 수 있습니다.
+<a href="./spec/auth-guard/auth-guard.spec.ts">auth-guard.spec.ts</a>, <a href="./spec/custom-swagger-decorator/apply-api-extra-model.spec.ts">apply-api-extra-model.spec.ts</a>, <a href="./spec/swagger-decorator">swagger-decorator</a>와 같이 method 별로 Decorator를 추가할 수 있습니다.
 
-Decorator의 기능이 CRUD에서 제공하는 기능일 경우 추가된 Decorator로 override 됩니다.
+Decorator의 기능이 CRUD에서 제공하는 기능과 중복될 경우 입력된 Decorator로 override 됩니다.
 
 ```
 @Crud({

--- a/spec/base/base.controller.read-one.spec.ts
+++ b/spec/base/base.controller.read-one.spec.ts
@@ -42,15 +42,20 @@ describe('BaseController', () => {
     describe('READ_ONE', () => {
         const id = 1;
         it('should be provided /:id', async () => {
-            const routerPathList = app.getHttpServer()._events.request._router.stack.reduce((list: Record<string, string[]>, r) => {
-                if (r.route?.path) {
-                    for (const method of Object.keys(r.route.methods)) {
-                        list[method] = list[method] ?? [];
-                        list[method].push(r.route.path);
-                    }
-                }
-                return list;
-            }, {});
+            const routerPathList = app
+                .getHttpServer()
+                ._events.request._router.stack.reduce(
+                    (list: Record<string, string[]>, r: { route: { path: string; methods: { methods: unknown } } }) => {
+                        if (r.route?.path) {
+                            for (const method of Object.keys(r.route.methods)) {
+                                list[method] = list[method] ?? [];
+                                list[method].push(r.route.path);
+                            }
+                        }
+                        return list;
+                    },
+                    {},
+                );
             expect(routerPathList.get).toEqual(expect.arrayContaining(['/base/:id']));
         });
 

--- a/spec/swagger-decorator/read-one.request.interceptor.ts
+++ b/spec/swagger-decorator/read-one.request.interceptor.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { Request } from 'express';
+
+import { CustomRequestInterceptor, CustomReadOneRequestOptions } from '../../src';
+
+@Injectable()
+export class ReadOneRequestInterceptor extends CustomRequestInterceptor {
+    async overrideOptions(req: Request): Promise<CustomReadOneRequestOptions> {
+        return new Promise((resolve, _reject) => {
+            if (req.params?.['key']) {
+                delete req.params.key;
+            }
+            resolve({});
+        });
+    }
+}

--- a/spec/swagger-decorator/swagger-decorator.controller.ts
+++ b/spec/swagger-decorator/swagger-decorator.controller.ts
@@ -1,0 +1,25 @@
+import { Controller } from '@nestjs/common';
+import { ApiParam } from '@nestjs/swagger';
+
+import { ReadOneRequestInterceptor } from './read-one.request.interceptor';
+import { Crud } from '../../src/lib/crud.decorator';
+import { CrudController } from '../../src/lib/interface';
+import { BaseEntity } from '../base/base.entity';
+import { BaseService } from '../base/base.service';
+
+@Crud({
+    entity: BaseEntity,
+    routes: {
+        readOne: {
+            interceptors: [ReadOneRequestInterceptor],
+            decorators: [ApiParam({ name: 'key', required: true })],
+        },
+        readMany: {
+            decorators: [ApiParam({ name: 'key', required: true })],
+        },
+    },
+})
+@Controller('swagger-decorator/:key')
+export class SwaggerDecoratorController implements CrudController<BaseEntity> {
+    constructor(public readonly crudService: BaseService) {}
+}

--- a/spec/swagger-decorator/swagger-decorator.module.ts
+++ b/spec/swagger-decorator/swagger-decorator.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { SwaggerDecoratorController } from './swagger-decorator.controller';
+import { BaseEntity } from '../base/base.entity';
+import { BaseService } from '../base/base.service';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([BaseEntity])],
+    controllers: [SwaggerDecoratorController],
+    providers: [BaseService],
+})
+export class SwaggerDecoratorModule {}

--- a/spec/swagger-decorator/swagger-decorator.spec.ts
+++ b/spec/swagger-decorator/swagger-decorator.spec.ts
@@ -1,0 +1,65 @@
+import { HttpStatus, INestApplication } from '@nestjs/common';
+import { TestingModule, Test } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import request from 'supertest';
+
+import { SwaggerDecoratorModule } from './swagger-decorator.module';
+import { BaseEntity } from '../base/base.entity';
+
+describe('SwaggerDecorator', () => {
+    let app: INestApplication;
+
+    beforeEach(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [
+                SwaggerDecoratorModule,
+                TypeOrmModule.forRoot({
+                    type: 'sqlite',
+                    database: ':memory:',
+                    entities: [BaseEntity],
+                    synchronize: true,
+                    logging: true,
+                    logger: 'file',
+                }),
+            ],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+
+        await app.init();
+    });
+
+    afterAll(async () => {
+        if (app) {
+            await app.close();
+        }
+    });
+
+    it('should be added swagger decorator', async () => {
+        const routerPathList = app
+            .getHttpServer()
+            ._events.request._router.stack.reduce(
+                (list: Record<string, string[]>, r: { route: { path: string; methods: { methods: unknown } } }) => {
+                    if (r.route?.path) {
+                        for (const method of Object.keys(r.route.methods)) {
+                            list[method] = list[method] ?? [];
+                            list[method].push(r.route.path);
+                        }
+                    }
+                    return list;
+                },
+                {},
+            );
+        expect(routerPathList.get).toEqual(expect.arrayContaining(['/swagger-decorator/:key/:id', '/swagger-decorator/:key']));
+
+        const response = await request(app.getHttpServer()).post('/swagger-decorator/123').send({ name: 'name' });
+        expect(response.status).toEqual(HttpStatus.CREATED);
+        expect(response.body.name).toEqual('name');
+
+        await request(app.getHttpServer()).get('/swagger-decorator/456').expect(HttpStatus.OK);
+
+        const readOneResponse = await request(app.getHttpServer()).get(`/swagger-decorator/456/${response.body.id}`);
+        expect(readOneResponse.status).toEqual(HttpStatus.OK);
+        expect(readOneResponse.body.name).toEqual('name');
+    });
+});

--- a/src/lib/crud.route.factory.ts
+++ b/src/lib/crud.route.factory.ts
@@ -187,16 +187,17 @@ export class CrudRouteFactory {
             Reflect.defineMetadata(HTTP_CODE_METADATA, HttpStatus.OK, targetMethod);
         }
 
-        const customDecorator = this.crudOptions.routes?.[crudMethod]?.decorators ?? [];
+        const customDecorators = this.crudOptions.routes?.[crudMethod]?.decorators ?? [];
 
-        if (customDecorator.length > 0) {
-            const decoratorDescriptor = Reflect.decorate(
-                customDecorator,
-                targetMethod,
-                methodNameOnController,
-                Reflect.getOwnPropertyDescriptor(targetMethod, methodNameOnController),
-            );
-            Reflect.defineProperty(targetMethod, methodNameOnController, decoratorDescriptor);
+        if (customDecorators.length > 0) {
+            for (const decorator of customDecorators) {
+                const descriptor = Reflect.getOwnPropertyDescriptor(targetMethod, methodNameOnController);
+                (decorator as MethodDecorator | PropertyDecorator)(
+                    targetMethod,
+                    methodNameOnController,
+                    descriptor ?? { value: targetMethod },
+                );
+            }
         }
 
         Reflect.defineMetadata(PATH_METADATA, path, targetMethod);


### PR DESCRIPTION
Change how `decorator defined`.

I referred to [applyDecorators](https://github.com/nestjs/nest/blob/99ee3fd99341bcddfa408d1604050a9571b19bc9/packages/common/decorators/core/apply-decorators.ts#L10) and [helpers.ts](https://github.com/nestjs/swagger/blob/0f971f6939fa11f30fd9c677ffa41b7e3435743a/lib/decorators/helpers.ts)

As in @Param decorator(like added unit-test), `Decorator` and `Interceptor` need to be used together.

#### Issue 

When i define a swagger decorator in route option of crud decorator`s method, the following error occurs:
```
/Users/jiho/git/nestjs-monorepo/node_modules/reflect-metadata/Reflect.js:553
                var decorated = decorator(target, propertyKey, descriptor);
                                ^
TypeError: Cannot read properties of undefined (reading 'value')
    at /Users/jiho/git/nestjs-monorepo/node_modules/@nestjs/swagger/dist/decorators/helpers.js:66:98
    at DecorateProperty (/Users/jiho/git/nestjs-monorepo/node_modules/reflect-metadata/Reflect.js:553:33)
    at Reflect.decorate (/Users/jiho/git/nestjs-monorepo/node_modules/reflect-metadata/Reflect.js:123:24)
    at CrudRouteFactory.createMethod (/Users/jiho/git/nestjs-monorepo/node_modules/@nestjs-library/crud/src/lib/crud.route.factory.ts:193:49)
    at CrudRouteFactory.init (/Users/jiho/git/nestjs-monorepo/node_modules/@nestjs-library/crud/src/lib/crud.route.factory.ts:66:18)
    at /Users/jiho/git/nestjs-monorepo/node_modules/@nestjs-library/crud/src/lib/crud.decorator.ts:9:26
    at DecorateConstructor (/Users/jiho/git/nestjs-monorepo/node_modules/reflect-metadata/Reflect.js:541:33)
    at Reflect.decorate (/Users/jiho/git/nestjs-monorepo/node_modules/reflect-metadata/Reflect.js:130:24)
    at Object.__decorate (/Users/jiho/git/nestjs-monorepo/node_modules/tslib/tslib.js:103:96)
```