### PR TITLE
feat: handle case when validator groups is undefined

### DIFF
--- a/src/lib/dto/request.dto.ts
+++ b/src/lib/dto/request.dto.ts
@@ -18,7 +18,7 @@ export function CreateRequestDto(parentClass: typeof BaseEntity, group: Method) 
     const propertyNamesAppliedValidation = [
         ...new Set(
             targetMetadata
-                .filter(({ groups, always }) => always === true || groups.includes(group))
+                .filter(({ groups, always }) => always === true || (groups ?? []).includes(group))
                 .map(({ propertyName }) => propertyName),
         ),
     ];


### PR DESCRIPTION
When using class validator without `always` nor `groups` option, it throws TypeError.

 It needs to be handle 💡