### PR TITLE
feat: swagger body interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "@nestjs/common": "^9.2.1",
         "@nestjs/core": "^9.2.1",
         "@nestjs/platform-express": "^9.0.0",
-        "@nestjs/swagger": "^6.1.4",
+        "@nestjs/swagger": "^6.2.1",
         "@nestjs/typeorm": "^9.0.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.13.2",

--- a/spec/base/base.controller.swagger.spec.ts
+++ b/spec/base/base.controller.swagger.spec.ts
@@ -218,5 +218,16 @@ describe('BaseController Swagger Decorator', () => {
         expect(routeSet[search].root?.method).toEqual('post');
         expect(routeSet[search].root?.summary).toEqual("Search from 'Base' Table");
         expect(routeSet[search].root?.description).toEqual("Fetch multiple entities in 'Base' Table via custom query in body");
+        expect(routeSet[search].root?.requestBody).toEqual({
+            description: 'SearchBaseDto',
+            required: true,
+            content: {
+                'application/json': {
+                    schema: {
+                        $ref: '#/components/schemas/RequestSearchDto',
+                    },
+                },
+            },
+        });
     });
 });

--- a/spec/exclude-swagger/exclude-swagger.controller.ts
+++ b/spec/exclude-swagger/exclude-swagger.controller.ts
@@ -1,11 +1,12 @@
 import { Controller } from '@nestjs/common';
+import { PickType } from '@nestjs/swagger';
 
 import { Crud } from '../../src/lib/crud.decorator';
 import { CrudController } from '../../src/lib/interface';
 import { BaseEntity } from '../base/base.entity';
 import { BaseService } from '../base/base.service';
 
-@Crud({ entity: BaseEntity, routes: { recover: { swagger: false } } })
+@Crud({ entity: BaseEntity, routes: { recover: { swagger: false }, create: { body: PickType(BaseEntity, ['name']) } } })
 @Controller('exclude-swagger')
 export class ExcludeSwaggerController implements CrudController<BaseEntity> {
     constructor(public readonly crudService: BaseService) {}

--- a/src/lib/crud.route.factory.ts
+++ b/src/lib/crud.route.factory.ts
@@ -15,6 +15,7 @@ import { MetadataUtils } from 'typeorm/metadata-builder/MetadataUtils';
 
 import { Constants } from './constants';
 import { CRUD_POLICY } from './crud.policy';
+import { RequestSearchDto } from './dto/request-search.dto';
 import { CreateRequestDto } from './dto/request.dto';
 import {
     CrudOptions,
@@ -263,7 +264,17 @@ export class CrudRouteFactory {
                 description: [capitalizeFirstLetter(method), capitalizeFirstLetter(this.tableName), 'Dto'].join(''),
                 required: true,
                 in: 'body',
-                type: CreateRequestDto(this.crudOptions.entity, method),
+                type: (() => {
+                    if (method === Method.SEARCH) {
+                        return RequestSearchDto;
+                    }
+                    const routeConfig = this.crudOptions.routes?.[method];
+                    if (routeConfig && 'body' in routeConfig) {
+                        return routeConfig['body'];
+                    }
+
+                    return CreateRequestDto(this.crudOptions.entity, method);
+                })(),
                 isArray: false,
             });
         }

--- a/src/lib/interface/decorator-option.interface.ts
+++ b/src/lib/interface/decorator-option.interface.ts
@@ -35,9 +35,12 @@ export interface CrudOptions {
             softDelete?: boolean;
             relations?: false | string[];
         } & RouteBaseOption;
-        [Method.CREATE]?: RouteBaseOption;
+        [Method.CREATE]?: {
+            body?: Type<unknown>;
+        } & RouteBaseOption;
         [Method.UPDATE]?: {
             params?: string[];
+            body?: Type<unknown>;
         } & RouteBaseOption;
         [Method.DELETE]?: {
             params?: string[];
@@ -45,6 +48,7 @@ export interface CrudOptions {
         } & RouteBaseOption;
         [Method.UPSERT]?: {
             params?: string[];
+            body?: Type<unknown>;
         } & RouteBaseOption;
         [Method.RECOVER]?: {
             params?: string[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -792,10 +792,10 @@
     tslib "2.4.1"
     uuid "9.0.0"
 
-"@nestjs/mapped-types@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@nestjs/mapped-types/-/mapped-types-1.2.0.tgz#1bbdbb5c956f0adb3fd76add929137bc6ad3183f"
-  integrity sha512-NTFwPZkQWsArQH8QSyFWGZvJ08gR+R4TofglqZoihn/vU+ktHEJjMqsIsADwb7XD97DhiD+TVv5ac+jG33BHrg==
+"@nestjs/mapped-types@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@nestjs/mapped-types/-/mapped-types-1.2.2.tgz#d9ddb143776e309dbc1a518ac1607fddac1e140e"
+  integrity sha512-3dHxLXs3M0GPiriAcCFFJQHoDFUuzTD5w6JDhE7TyfT89YKpe6tcCCIqOZWdXmt9AZjjK30RkHRSFF+QEnWFQg==
 
 "@nestjs/platform-express@^9.0.0":
   version "9.2.1"
@@ -808,12 +808,12 @@
     multer "1.4.4-lts.1"
     tslib "2.4.1"
 
-"@nestjs/swagger@^6.1.4":
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/@nestjs/swagger/-/swagger-6.1.4.tgz#ef48abc401253b3e475d44aba8bcded7975341df"
-  integrity sha512-kE8VjR+NaoKqxg8XqM/YYfALScPh4AcoR8Wywga8/OxHsTHY+MKxqvTpWp7IhCUWSA6xT8nQUpcC9Rt7C+r7Hw==
+"@nestjs/swagger@^6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@nestjs/swagger/-/swagger-6.2.1.tgz#38caa76ac00993ddc11a79dd24ab9f4392d2791d"
+  integrity sha512-9M2vkfJHIzLqDZwvM5TEZO0MxRCvIb0xVy0LsmWwxH1lrb0z/4MhU+r2CWDhBtTccVJrKxVPiU2s3T3b9uUJbg==
   dependencies:
-    "@nestjs/mapped-types" "1.2.0"
+    "@nestjs/mapped-types" "1.2.2"
     js-yaml "4.1.0"
     lodash "4.17.21"
     path-to-regexp "3.2.0"


### PR DESCRIPTION
#### feat: when body interface is different from entity, change body interface.
- CREATE, UPDATE and UPSERT with body can be set to Decorator option
```
@Crud({
    entity: BaseEntity,
    routes: {
        create: { body: PickType(BaseEntity, ['name']) }
    }
})
```

#### fix: search body interface.
- Search Method`s body be **RequestSearchDto**, not Entity