### PR TITLE
feat: improve crud create interface

### DIFF
--- a/src/lib/abstract/crud.abstract.service.ts
+++ b/src/lib/abstract/crud.abstract.service.ts
@@ -1,15 +1,16 @@
 import { BaseEntity } from 'typeorm';
 
 import {
-    PaginationResponse,
+    CrudCreateManyRequest,
+    CrudCreateOneRequest,
+    CrudDeleteOneRequest,
     CrudReadManyRequest,
     CrudReadOneRequest,
-    CrudSearchRequest,
-    CrudCreateRequest,
-    CrudUpsertRequest,
-    CrudUpdateOneRequest,
-    CrudDeleteOneRequest,
     CrudRecoverRequest,
+    CrudSearchRequest,
+    CrudUpdateOneRequest,
+    CrudUpsertRequest,
+    PaginationResponse,
 } from '../interface';
 
 /**
@@ -24,7 +25,8 @@ export abstract class CrudAbstractService<T extends BaseEntity> {
 
     abstract reservedSearch(req: CrudSearchRequest<T>): Promise<{ data: Array<CrudResponseType<T>> }>;
 
-    abstract reservedCreate(req: CrudCreateRequest<T>): Promise<CrudResponseType<T> | Array<CrudResponseType<T>>>;
+    abstract reservedCreate(req: CrudCreateOneRequest<T>): Promise<CrudResponseType<T>>;
+    abstract reservedCreate(req: CrudCreateManyRequest<T>): Promise<Array<CrudResponseType<T>>>;
 
     abstract reservedUpsert(req: CrudUpsertRequest<T>): Promise<CrudResponseType<T>>;
 

--- a/src/lib/interface/request.interface.ts
+++ b/src/lib/interface/request.interface.ts
@@ -1,6 +1,6 @@
 import { DeepPartial } from 'typeorm';
 
-import { PrimaryKey, Sort, PaginationRequest, CrudResponseOptions } from '.';
+import { CrudResponseOptions, PaginationRequest, PrimaryKey, Sort } from '.';
 import { RequestSearchDto } from '../dto/request-search.dto';
 
 export type CrudRequestId<T> = keyof T | Array<keyof T>;
@@ -34,15 +34,25 @@ export interface CrudSearchRequest<T> extends CrudRequestBase {
     relations?: string[];
 }
 
-export interface CrudCreateRequest<T> extends CrudRequestBase {
-    body: DeepPartial<T> | Array<DeepPartial<T>>;
+export interface CrudCreateOneRequest<T> extends CrudRequestBase {
+    body: DeepPartial<T>;
 }
 
-export interface CrudUpsertRequest<T> extends CrudCreateRequest<T> {
+export interface CrudCreateManyRequest<T> extends CrudRequestBase {
+    body: Array<DeepPartial<T>>;
+}
+
+export function isCrudCreateManyRequest<T>(x: CrudCreateOneRequest<T> | CrudCreateManyRequest<T>): x is CrudCreateManyRequest<T> {
+    return Array.isArray(x.body);
+}
+
+export type CrudCreateRequest<T> = CrudCreateOneRequest<T> | CrudCreateManyRequest<T>;
+
+export interface CrudUpsertRequest<T> extends CrudCreateOneRequest<T> {
     params: Partial<Record<keyof T, unknown>>;
 }
 
-export interface CrudUpdateOneRequest<T> extends CrudCreateRequest<T> {
+export interface CrudUpdateOneRequest<T> extends CrudCreateOneRequest<T> {
     params: Partial<Record<keyof T, unknown>>;
 }
 


### PR DESCRIPTION
엔티티들을 생성하기 위해 `reservedCreate(...)`를 호출할 때 body의 타입이 엔티티의 배열인 경우 응답을 엔티티 배열로, body가 엔티티인 경우 응답을 엔티티가 되도록 변경했습니다.
`reservedCreate`를 활용할 경우 응답값을 활용하는데 도움이 됩니다.