### PR TITLE
refactor: expand swagger in decorator options

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -192,7 +192,7 @@ Decorator Option으로 route 마다 `swagger`를 비 활성화 할 수 있습니
 <a href="./spe/exclude-swagger/exclude-swagger.spec.ts">exclude-swagger.spec.ts</a>와 같이 method 별로 Swagger를 비활성화 할 수 있습니다.
 
 ```
-@Crud({ entity: BaseEntity, routes: { recover: { swagger: false } } })
+@Crud({ entity: BaseEntity, routes: { recover: { swagger: { hide: true } } } })
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Decorator Option으로 route 마다 `swagger`를 비 활성화 할 수 있습니
 <a href="./spe/exclude-swagger/exclude-swagger.spec.ts">exclude-swagger.spec.ts</a>와 같이 method 별로 Swagger를 비활성화 할 수 있습니다.
 
 ```
-@Crud({ entity: BaseEntity, routes: { recover: { swagger: false } } })
+@Crud({ entity: BaseEntity, routes: { recover: { swagger: { hide: true } } } })
 ```
 
 ---

--- a/spec/exclude-swagger/exclude-swagger.controller.ts
+++ b/spec/exclude-swagger/exclude-swagger.controller.ts
@@ -6,7 +6,10 @@ import { CrudController } from '../../src/lib/interface';
 import { BaseEntity } from '../base/base.entity';
 import { BaseService } from '../base/base.service';
 
-@Crud({ entity: BaseEntity, routes: { recover: { swagger: false }, create: { body: PickType(BaseEntity, ['name']) } } })
+@Crud({
+    entity: BaseEntity,
+    routes: { recover: { swagger: { hide: true } }, create: { swagger: { body: PickType(BaseEntity, ['name']) } } },
+})
 @Controller('exclude-swagger')
 export class ExcludeSwaggerController implements CrudController<BaseEntity> {
     constructor(public readonly crudService: BaseService) {}

--- a/src/lib/crud.route.factory.ts
+++ b/src/lib/crud.route.factory.ts
@@ -206,7 +206,7 @@ export class CrudRouteFactory {
     }
 
     private applySwaggerDecorator(method: Method, params: string[], target: Object) {
-        if (this.crudOptions.routes?.[method]?.swagger === false) {
+        if (this.crudOptions.routes?.[method]?.swagger?.hide) {
             Reflect.defineMetadata(DECORATORS.API_EXCLUDE_ENDPOINT, { disable: true }, target);
             return;
         }

--- a/src/lib/interface/decorator-option.interface.ts
+++ b/src/lib/interface/decorator-option.interface.ts
@@ -7,7 +7,9 @@ interface RouteBaseOption {
     decorators?: Array<PropertyDecorator | MethodDecorator>;
     interceptors?: Array<Type<NestInterceptor>>;
     response?: CrudResponseOptions;
-    swagger?: boolean;
+    swagger?: {
+        hide?: boolean;
+    };
 }
 
 export interface PrimaryKey {
@@ -36,11 +38,15 @@ export interface CrudOptions {
             relations?: false | string[];
         } & RouteBaseOption;
         [Method.CREATE]?: {
-            body?: Type<unknown>;
+            swagger?: {
+                body?: Type<unknown>;
+            };
         } & RouteBaseOption;
         [Method.UPDATE]?: {
             params?: string[];
-            body?: Type<unknown>;
+            swagger?: {
+                body?: Type<unknown>;
+            };
         } & RouteBaseOption;
         [Method.DELETE]?: {
             params?: string[];
@@ -48,7 +54,9 @@ export interface CrudOptions {
         } & RouteBaseOption;
         [Method.UPSERT]?: {
             params?: string[];
-            body?: Type<unknown>;
+            swagger?: {
+                body?: Type<unknown>;
+            };
         } & RouteBaseOption;
         [Method.RECOVER]?: {
             params?: string[];


### PR DESCRIPTION
### expand swagger in decorator options

> This change causes `breaking change`.

The swagger option in the decorator only provides `enable & hide`.

Extends the options associated with the swagger, including features added in [PR#18](https://github.com/woowabros/nestjs-library-crud/pull/18).

`Breaking change` occurs, but it will `help add settings` related to the swagger.

Please let me know your opinion.

#### break change
Two breaking changes
```
# Turn off swagger
// AS-IS
@Crud({ entity: BaseEntity, routes: { recover: { swagger: false } } })
// TO-BE
@Crud({ entity: BaseEntity, routes: { recover: { swagger: { hide: true } } })
```

```
# Change Swagger Body Interface
// AS-IS
@Crud({ entity: BaseEntity, routes: { create: { body: PickType(BaseEntity, ['name']) } } })
// TO-BE
@Crud({ entity: BaseEntity, routes: { create: { swagger: { body: PickType(BaseEntity, ['name']) } } } })
```
