### PR TITLE
feat: define method on CrudAbstractService

### DIFF
--- a/src/lib/abstract/crud.abstract.service.ts
+++ b/src/lib/abstract/crud.abstract.service.ts
@@ -13,10 +13,6 @@ import {
     PaginationResponse,
 } from '../interface';
 
-/**
- * Rule
- * - Interceptor로부터 전달받는 Request는 첫번째 Argument로 사용합니다.
- */
 export abstract class CrudAbstractService<T extends BaseEntity> {
     abstract reservedReadMany(req: CrudReadManyRequest<T>): Promise<PaginationResponse<T>>;
 
@@ -34,4 +30,6 @@ export abstract class CrudAbstractService<T extends BaseEntity> {
     abstract reservedDelete(req: CrudDeleteOneRequest<T>): Promise<T>;
 
     abstract reservedRecover(req: CrudRecoverRequest<T>): Promise<T>;
+
+    abstract getTotalCountByCrudReadManyRequest(req: CrudReadManyRequest<T>): Promise<number>;
 }


### PR DESCRIPTION
Defines the method added in https://github.com/woowabros/nestjs-library-crud/pull/35 on CrudAbstractService.

```
# crud.service.d.ts
import { BaseEntity, Repository } from 'typeorm';
import { CrudAbstractService } from './abstract/crud.abstract.service';
import { CrudReadManyRequest, CrudReadOneRequest, CrudDeleteOneRequest, CrudUpdateOneRequest, CrudUpsertRequest, CrudRecoverRequest, PaginationResponse, CrudSearchRequest, CrudCreateOneRequest, CrudCreateManyRequest } from './interface';
export declare class CrudService<T extends BaseEntity> extends CrudAbstractService<T> {
    readonly repository: Repository<T>;
    private primaryKey;
    private relations;
    constructor(repository: Repository<T>);
    reservedSearch(crudSearchRequest: CrudSearchRequest<T>): Promise<{
        data: T[];
    }>;
    reservedReadMany(crudReadManyRequest: CrudReadManyRequest<T>): Promise<PaginationResponse<T>>;
    getTotalCountByCrudReadManyRequest(crudReadManyRequest: CrudReadManyRequest<T>): Promise<number>;
    reservedReadOne(crudReadOneRequest: CrudReadOneRequest<T>): Promise<T>;
    reservedCreate(req: CrudCreateOneRequest<T>): Promise<T>;
    reservedCreate(req: CrudCreateManyRequest<T>): Promise<T[]>;
    reservedUpsert(crudUpsertRequest: CrudUpsertRequest<T>): Promise<T>;
    reservedUpdate(crudUpdateOneRequest: CrudUpdateOneRequest<T>): Promise<T>;
    reservedDelete(crudDeleteOneRequest: CrudDeleteOneRequest<T>): Promise<T>;
    reservedRecover(crudRecoverRequest: CrudRecoverRequest<T>): Promise<T>;
    private paginateCursorTotalCount;
    private paginateCursor;
    private paginateCursorWhereByToken;
    private paginateOffsetTotalCount;
    private paginateOffset;
    private getRelation;
}
```