### PR TITLE
feat: cursor pagination on search

### DIFF
--- a/spec/search/module.ts
+++ b/spec/search/module.ts
@@ -1,21 +1,26 @@
 /* eslint-disable max-classes-per-file */
 import { Controller, Injectable, Module } from '@nestjs/common';
 import { InjectRepository, TypeOrmModule } from '@nestjs/typeorm';
+import { IsOptional } from 'class-validator';
 import { Entity, BaseEntity, Repository, PrimaryColumn, Column } from 'typeorm';
 
 import { Crud } from '../../src/lib/crud.decorator';
 import { CrudService } from '../../src/lib/crud.service';
+import { GROUP } from '../../src/lib/interface';
 import { CrudController } from '../../src/lib/interface';
 
 @Entity('TestEntity')
 export class TestEntity extends BaseEntity {
     @PrimaryColumn()
+    @IsOptional({ groups: [GROUP.SEARCH] })
     col1: string;
 
     @Column()
+    @IsOptional({ groups: [GROUP.SEARCH] })
     col2: number;
 
     @Column({ nullable: true })
+    @IsOptional({ groups: [GROUP.SEARCH] })
     col3: number;
 }
 

--- a/spec/search/search-cursor-pagination.spec.ts
+++ b/spec/search/search-cursor-pagination.spec.ts
@@ -1,0 +1,88 @@
+import { INestApplication, HttpStatus } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import _ from 'lodash';
+import request from 'supertest';
+
+import { TestEntity, TestModule, TestService } from './module';
+import { PaginationHelper } from '../../src/lib/provider';
+import { TestHelper } from '../test.helper';
+
+describe('Search Cursor Pagination', () => {
+    let app: INestApplication;
+    let service: TestService;
+
+    beforeEach(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [TestModule, TestHelper.getTypeOrmMysqlModule([TestEntity])],
+        }).compile();
+        app = moduleFixture.createNestApplication();
+        service = moduleFixture.get<TestService>(TestService);
+
+        /**
+         * 50 entities are created for the test.
+         *
+         * col1
+         * - An even number starts with col0.
+         * - Odd numbers start with col1
+         *
+         * col2
+         * - Same as the index number [0-49]
+         * - main information for testing.
+         *
+         * col3
+         * - when index is [0-24], it has [50-26]
+         * - when index is [25-49], is has null
+         */
+        await Promise.all(
+            _.range(25).map((no: number) =>
+                service.repository.save(
+                    service.repository.create({ col1: `col${no % 2 === 0 ? '0' : '1'}_${no}`, col2: no, col3: 50 - no }),
+                ),
+            ),
+        );
+        await Promise.all(
+            _.range(25, 50).map((no: number) =>
+                service.repository.save(service.repository.create({ col1: `col${no % 2 === 0 ? '0' : '1'}_${no}`, col2: no })),
+            ),
+        );
+
+        await app.init();
+    });
+
+    afterEach(async () => {
+        await TestHelper.dropTypeOrmEntityTables();
+        await app?.close();
+    });
+
+    it('should fetch with nextCursor', async () => {
+        const searchRequestBody = { where: [{ col2: { operator: '<', operand: 40 } }], order: { col1: 'DESC' }, take: 10 };
+
+        const firstResponse = await request(app.getHttpServer()).post('/base/search').send(searchRequestBody);
+        expect(firstResponse.statusCode).toEqual(HttpStatus.OK);
+        expect(firstResponse.body.data).toHaveLength(10);
+
+        const lastEntity = PaginationHelper.deserialize<TestEntity>(firstResponse.body.metadata.nextCursor);
+        expect(lastEntity).toEqual({ col1: 'col1_29' });
+        const preCondition = PaginationHelper.deserialize(firstResponse.body.metadata.query);
+        expect(preCondition).toEqual({ ...searchRequestBody, withDeleted: false });
+
+        const secondResponse = await request(app.getHttpServer())
+            .post('/base/search')
+            .send({ nextCursor: firstResponse.body.metadata.nextCursor, query: firstResponse.body.metadata.query });
+
+        expect(secondResponse.statusCode).toEqual(HttpStatus.OK);
+        expect(secondResponse.body.data).toHaveLength(10);
+        const firstDataCol1: Set<string> = new Set(firstResponse.body.data.map((d: { col1: string }) => d.col1));
+
+        for (const nextData of secondResponse.body.data) {
+            expect(firstDataCol1.has(nextData.col1)).not.toBeTruthy();
+        }
+
+        const nextLastEntity = PaginationHelper.deserialize(secondResponse.body.metadata.nextCursor);
+        expect(nextLastEntity).toEqual({ col1: 'col1_1' });
+        const nextPreCondition = PaginationHelper.deserialize(secondResponse.body.metadata.query);
+        expect(nextPreCondition).toEqual(
+            _.merge(searchRequestBody, { where: [{ col1: { operand: lastEntity.col1, operator: '<' } }] }, { withDeleted: false }),
+        );
+    });
+});

--- a/spec/search/search-query-operator.spec.ts
+++ b/spec/search/search-query-operator.spec.ts
@@ -63,9 +63,12 @@ describe('Search Query Operator', () => {
         ];
 
         for (const requestSearchDto of requestSearchDtoList) {
-            const { data } = await service.reservedSearch({ requestSearchDto });
+            const { data, metadata } = await service.reservedSearch({ requestSearchDto });
             expect(data).toHaveLength(5);
             expect(Object.keys(data[0])).toEqual(expect.arrayContaining(requestSearchDto.select as unknown[]));
+
+            expect(metadata.nextCursor).toBeDefined();
+            expect(metadata.query).toBeDefined();
         }
     });
 
@@ -105,16 +108,19 @@ describe('Search Query Operator', () => {
             [{ where: [{ col3: { operator: 'NULL', not: true } }] }, [0, 1, 2, 3, 4]],
         ];
         for (const [requestSearchDto, expected] of fixtures) {
-            const { data } = await service.reservedSearch({ requestSearchDto });
+            const { data, metadata } = await service.reservedSearch({ requestSearchDto });
             const col2Values = data.map((d) => d.col2);
             expect(col2Values).toHaveLength(expected.length);
             expect(col2Values).toEqual(expect.arrayContaining(expected));
+
+            expect(metadata.nextCursor).toBeDefined();
+            expect(metadata.query).toBeDefined();
         }
     });
 
     it('nested complex where condition test', async () => {
         const fixtures: Array<[RequestSearchDto<TestEntity>, number[]]> = [
-            [{ where: [{ col2: { operator: 'BETWEEN', operand: [3, 5] } }] }, [3, 4, 5]],
+            [{ where: [{ col2: { operator: 'BETWEEN', operand: [3, 5] } }], order: { col1: 'ASC' } }, [3, 4, 5]],
             [
                 {
                     where: [
@@ -143,17 +149,27 @@ describe('Search Query Operator', () => {
                 [3, 5, 6],
             ],
             [{ where: [{ col3: { operator: 'NULL' }, col2: { operator: 'IN', operand: [1, 3, 5] } }] }, [5]],
-            [{ where: [{ col3: { operator: 'NULL', not: true }, col2: { operator: 'IN', operand: [1, 3, 5] } }] }, [1, 3]],
             [
-                { where: [{ col2: { operator: 'BETWEEN', operand: [4, 6], not: true }, col3: { operator: 'BETWEEN', operand: [3, 9] } }] },
+                {
+                    where: [{ col3: { operator: 'NULL', not: true }, col2: { operator: 'IN', operand: [1, 3, 5] } }],
+                },
+                [1, 3],
+            ],
+            [
+                {
+                    where: [{ col2: { operator: 'BETWEEN', operand: [4, 6], not: true }, col3: { operator: 'BETWEEN', operand: [3, 9] } }],
+                },
                 [1, 2, 3],
             ],
         ];
         for (const [requestSearchDto, expected] of fixtures) {
-            const { data } = await service.reservedSearch({ requestSearchDto });
+            const { data, metadata } = await service.reservedSearch({ requestSearchDto });
             const col2Values = data.map((d) => d.col2);
             expect(col2Values).toHaveLength(expected.length);
             expect(col2Values).toEqual(expect.arrayContaining(expected));
+
+            expect(metadata.nextCursor).toBeDefined();
+            expect(metadata.query).toBeDefined();
         }
     });
 });

--- a/src/lib/abstract/crud.abstract.service.ts
+++ b/src/lib/abstract/crud.abstract.service.ts
@@ -32,4 +32,6 @@ export abstract class CrudAbstractService<T extends BaseEntity> {
     abstract reservedRecover(req: CrudRecoverRequest<T>): Promise<T>;
 
     abstract getTotalCountByCrudReadManyRequest(req: CrudReadManyRequest<T>): Promise<number>;
+
+    abstract getTotalCountByCrudSearchRequest(req: CrudSearchRequest<T>): Promise<number>;
 }

--- a/src/lib/crud.policy.ts
+++ b/src/lib/crud.policy.ts
@@ -93,6 +93,7 @@ export const CRUD_POLICY: Record<Method, CrudMethodPolicy> = {
         default: {
             numberOfTake: 20,
             softDeleted: false,
+            sort: Sort.DESC,
         },
     },
     [Method.READ_MANY]: {

--- a/src/lib/dto/request-search.dto.ts
+++ b/src/lib/dto/request-search.dto.ts
@@ -33,7 +33,7 @@ export class RequestSearchDto<T> {
 
     @ApiPropertyOptional({ description: 'order' })
     order?: {
-        [key in keyof Partial<T>]: Sort;
+        [key in keyof Partial<T>]: Sort | `${Sort}`;
     };
 
     @ApiPropertyOptional({ description: 'withDeleted', type: Boolean })
@@ -41,4 +41,10 @@ export class RequestSearchDto<T> {
 
     @ApiPropertyOptional({ description: 'take', type: Number })
     take?: number;
+
+    @ApiPropertyOptional({ description: 'Use to search the next page', type: String })
+    nextCursor?: string;
+
+    @ApiPropertyOptional({ description: 'Use to search the next page under the same conditions', type: String })
+    query?: string;
 }

--- a/src/lib/provider/index.ts
+++ b/src/lib/provider/index.ts
@@ -1,1 +1,2 @@
 export * from './execution-context-host.mock';
+export * from './pagination.helper';

--- a/src/lib/provider/pagination.helper.ts
+++ b/src/lib/provider/pagination.helper.ts
@@ -1,17 +1,18 @@
 const encoding = 'base64';
+
 export class PaginationHelper {
     static serialize<T>(entity: Partial<T>): string {
         return Buffer.from(JSON.stringify(entity)).toString(encoding);
     }
 
-    static deserialize(token?: string): Record<string, unknown> {
+    static deserialize<T>(token?: string): T {
         if (!token) {
-            return {};
+            return {} as T;
         }
         try {
             return JSON.parse(Buffer.from(token, encoding).toString());
         } catch {
-            return {};
+            return {} as T;
         }
     }
 }


### PR DESCRIPTION
provide pagination on search method.

Unlike readMany, it only provides cursor pagination.

The usage is the same as readMany.
- Provide metadata in response.
- `nextCursor` is used to query the next page.
- `query` is used to maintain the conditions on the first page.

Provides `getTotalCountByCrudSearchRequest` to get the total count by `CrudSearchRequest`.
