### PR TITLE
feat: limit take on search

### DIFF
--- a/spec/search/module.ts
+++ b/spec/search/module.ts
@@ -33,6 +33,11 @@ export class TestService extends CrudService<TestEntity> {
 
 @Crud({
     entity: TestEntity,
+    routes: {
+        search: {
+            limitOfTake: 100,
+        },
+    },
 })
 @Controller('base')
 export class TestController implements CrudController<TestEntity> {

--- a/spec/search/search-cursor-pagination.spec.ts
+++ b/spec/search/search-cursor-pagination.spec.ts
@@ -85,4 +85,14 @@ describe('Search Cursor Pagination', () => {
             _.merge(searchRequestBody, { where: [{ col1: { operand: lastEntity.col1, operator: '<' } }] }, { withDeleted: false }),
         );
     });
+
+    it('should be less than limitOfTake', async () => {
+        const { body } = await request(app.getHttpServer())
+            .post('/base/search')
+            .send({
+                take: 200,
+            })
+            .expect(HttpStatus.UNPROCESSABLE_ENTITY);
+        expect(body.message).toEqual('take must be less than 100');
+    });
 });

--- a/src/lib/interceptor/search-request.interceptor.ts
+++ b/src/lib/interceptor/search-request.interceptor.ts
@@ -72,8 +72,8 @@ export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption
 
             requestSearchDto.take =
                 'take' in requestSearchDto
-                    ? this.validateTake(requestSearchDto.take)
-                    : searchOptions.numberOfTake ?? (CRUD_POLICY[method].default?.numberOfTake as number);
+                    ? this.validateTake(requestSearchDto.take, searchOptions.limitOfTake)
+                    : searchOptions.limitOfTake ?? (CRUD_POLICY[method].default?.numberOfTake as number);
 
             return requestSearchDto;
         }
@@ -216,13 +216,16 @@ export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption
             }
         }
 
-        validateTake(take: RequestSearchDto<typeof crudOptions.entity>['take']): number | undefined {
+        validateTake(take: RequestSearchDto<typeof crudOptions.entity>['take'], limitOfTake: number | undefined): number | undefined {
             if (take == null) {
                 throw new UnprocessableEntityException('take must be positive number type');
             }
             const takeNumber = +take;
             if (!Number.isInteger(takeNumber) || takeNumber < 1) {
                 throw new UnprocessableEntityException('take must be positive number type');
+            }
+            if (!!limitOfTake && takeNumber > limitOfTake) {
+                throw new UnprocessableEntityException(`take must be less than ${limitOfTake}`);
             }
             return takeNumber;
         }

--- a/src/lib/interface/decorator-option.interface.ts
+++ b/src/lib/interface/decorator-option.interface.ts
@@ -33,7 +33,7 @@ export interface CrudOptions {
             softDelete?: boolean;
         } & Omit<RouteBaseOption, 'response'>;
         [Method.SEARCH]?: {
-            numberOfTake?: number;
+            limitOfTake?: number;
             softDelete?: boolean;
             relations?: false | string[];
         } & RouteBaseOption;


### PR DESCRIPTION
Using `search`, the requester can request the entities `without limitation` at `a time`.

This `flexibility` is a feature of search.

However, it can cause `high load` on the server.

I suggest to change the option `numberOfTake` to `limitOfTake`.
It's the `same as before`, and includes the function to `limit take of requester`.

