### PR TITLE
feat: use lodash assign rather than merge

### DIFF
--- a/src/lib/crud.service.ts
+++ b/src/lib/crud.service.ts
@@ -142,7 +142,7 @@ export class CrudService<T extends BaseEntity> extends CrudAbstractService<T> {
                     _.merge(upsertEntity, { [crudUpsertRequest.author.property]: crudUpsertRequest.author.value });
                 }
 
-                return this.repository.save(_.merge(upsertEntity, crudUpsertRequest.body));
+                return this.repository.save(_.assign(upsertEntity, crudUpsertRequest.body));
             });
     }
 
@@ -160,7 +160,7 @@ export class CrudService<T extends BaseEntity> extends CrudAbstractService<T> {
                     _.merge(entity, { [crudUpdateOneRequest.author.property]: crudUpdateOneRequest.author.value });
                 }
 
-                return this.repository.save(_.merge(entity, crudUpdateOneRequest.body));
+                return this.repository.save(_.assign(entity, crudUpdateOneRequest.body));
             });
     }
 


### PR DESCRIPTION
## Background

[lodash's merge](https://lodash.com/docs/4.17.15#merge) does not update original object's array property with new object's array property when new object's property is an empty array.

For example,
```Typescript
const originalObject = {
  id: '105',
  itemList: [{ id: 1, name: 'Item AA', categoryId: 6 }]
}

const newObject = {
  id: '105',
  itemList: []
}

const result = _.merge(originalObject, newObject);
console.log(result);
// expected
{
  id: '105',
  itemList: []
}

// output
{
  id: '105',
  itemList: [{ id: 1, name: 'Item AA', categoryId: 6 }]
}
```

In `CrudService.reservedUpdate` and `CrudService.reservedUpsert`, we expect to update the property with empty array.

## Change

replaces lodash's `.merge()` with `.assign()`

## Reference

[lodash merge should not ignore empty array](https://github.com/lodash/lodash/issues/1313) 