### PR TITLE
feat: search default number of take

### DIFF
--- a/spec/search/module.ts
+++ b/spec/search/module.ts
@@ -35,6 +35,7 @@ export class TestService extends CrudService<TestEntity> {
     entity: TestEntity,
     routes: {
         search: {
+            numberOfTake: 5,
             limitOfTake: 100,
         },
     },

--- a/spec/search/search-cursor-pagination.spec.ts
+++ b/spec/search/search-cursor-pagination.spec.ts
@@ -95,4 +95,16 @@ describe('Search Cursor Pagination', () => {
             .expect(HttpStatus.UNPROCESSABLE_ENTITY);
         expect(body.message).toEqual('take must be less than 100');
     });
+
+    it('should be fetch the entities count set in numberOfTake', async () => {
+        const {
+            body: { data: defaultData },
+        } = await request(app.getHttpServer()).post('/base/search').send({}).expect(HttpStatus.OK);
+        expect(defaultData).toHaveLength(5);
+
+        const {
+            body: { data: customData },
+        } = await request(app.getHttpServer()).post('/base/search').send({ take: 13 }).expect(HttpStatus.OK);
+        expect(customData).toHaveLength(13);
+    });
 });

--- a/src/lib/interceptor/search-request.interceptor.ts
+++ b/src/lib/interceptor/search-request.interceptor.ts
@@ -77,7 +77,7 @@ export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption
             requestSearchDto.take =
                 'take' in requestSearchDto
                     ? this.validateTake(requestSearchDto.take, searchOptions.limitOfTake)
-                    : searchOptions.limitOfTake ?? (CRUD_POLICY[method].default?.numberOfTake as number);
+                    : searchOptions.numberOfTake ?? (CRUD_POLICY[method].default?.numberOfTake as number);
 
             return requestSearchDto;
         }

--- a/src/lib/interface/decorator-option.interface.ts
+++ b/src/lib/interface/decorator-option.interface.ts
@@ -33,6 +33,7 @@ export interface CrudOptions {
             softDelete?: boolean;
         } & Omit<RouteBaseOption, 'response'>;
         [Method.SEARCH]?: {
+            numberOfTake?: number;
             limitOfTake?: number;
             softDelete?: boolean;
             relations?: false | string[];


### PR DESCRIPTION
Take limit of search is set in https://github.com/woowabros/nestjs-library-crud/pull/44 .

However, `limitOfTake` is used as a `limit value` and is also used as a `default value`.

The two objectives must be separable.

use the default value by `numberOfTake`.
