### PR TITLE
feat: explicit-member-accessibility lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -164,6 +164,19 @@ module.exports = {
                 'unicorn/string-content': 'off',
                 'unicorn/throw-new-error': 'error',
                 'unicorn/no-unnecessary-await': 'error',
+                '@typescript-eslint/explicit-member-accessibility': [
+                    'error',
+                    {
+                        accessibility: 'no-public',
+                        overrides: {
+                            accessors: 'no-public',
+                            constructors: 'off',
+                            methods: 'no-public',
+                            properties: 'off',
+                            parameterProperties: 'explicit',
+                        },
+                    },
+                ],
             },
         },
         {

--- a/src/lib/crud.route.factory.ts
+++ b/src/lib/crud.route.factory.ts
@@ -59,7 +59,7 @@ export class CrudRouteFactory {
         this.overrideMap = this.getOverrideMap();
     }
 
-    public init() {
+    init() {
         for (const method of Object.values(Method)) {
             if (!this.enabledMethod(method)) {
                 continue;

--- a/src/lib/override.decorator.spec.ts
+++ b/src/lib/override.decorator.spec.ts
@@ -1,18 +1,17 @@
 import 'reflect-metadata';
 
 import { Constants } from './constants';
-import { Method } from './interface';
 import { Override } from './override.decorator';
 
 describe('@Override', () => {
     it('should mark the method has been overridden', () => {
         class Test {
-            @Override(Method[Method.READ_ONE])
+            @Override('READ_ONE')
             // eslint-disable-next-line @typescript-eslint/no-empty-function
-            public static testMethod() {}
+            static testMethod() {}
         }
 
         const metadata = Reflect.getMetadata(Constants.OVERRIDE_METHOD_METADATA, Test.testMethod);
-        expect(metadata).toBe(Method[Method.READ_ONE]);
+        expect(metadata).toBe('READ_ONE');
     });
 });


### PR DESCRIPTION
Apply the lint rule [explicit-member-accessibility](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/explicit-member-accessibility.md).

use `accessibility: 'no-public'`, Not applicable on `constructors`.
