### PR TITLE
Exclude spec files from test coverage

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -34,7 +34,7 @@ const config: Config = {
             lines: 60,
         },
     },
-    coveragePathIgnorePatterns: ['<rootDir>/jest.config.ts', '.mock.ts'],
+    coveragePathIgnorePatterns: ['<rootDir>/jest.config.ts', '.mock.ts', 'spec/'],
     setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
 };
 

--- a/spec/param-option/param-option.non-entity-key.spec.ts
+++ b/spec/param-option/param-option.non-entity-key.spec.ts
@@ -6,7 +6,7 @@ import request from 'supertest';
 import { DynamicCrudModule } from '../dynamic-crud.module';
 import { TestHelper } from '../test.helper';
 
-describe('Params Option - entity의 key가 아닌 params으로 사용하는 경우', () => {
+describe('Params Option - used as params instead of key of entity', () => {
     let app: INestApplication;
     const param = 'unknownProperty';
 

--- a/spec/search/search-query-operator.spec.ts
+++ b/spec/search/search-query-operator.spec.ts
@@ -69,6 +69,8 @@ describe('Search Query Operator', () => {
 
             expect(metadata.nextCursor).toBeDefined();
             expect(metadata.query).toBeDefined();
+
+            expect(await service.getTotalCountByCrudSearchRequest({ requestSearchDto })).toEqual(10);
         }
     });
 


### PR DESCRIPTION
### Changed coverage targets

- Exclude `spec files` from test coverage
- Add `getTotalCountByCrudSearchRequest`  unit-test

### TO-BE
```
-----------------------------------|---------|----------|---------|---------|-------------------
File                               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------------------|---------|----------|---------|---------|-------------------
All files                          |   98.61 |    91.97 |   99.03 |   98.67 |                   
 src                               |     100 |      100 |     100 |     100 |                   
  index.ts                         |     100 |      100 |     100 |     100 |                   
 src/lib                           |    97.5 |    93.35 |   98.37 |   97.65 |                   
  constants.ts                     |     100 |      100 |     100 |     100 |                   
  crud.decorator.ts                |     100 |      100 |     100 |     100 |                   
  crud.policy.ts                   |     100 |      100 |     100 |     100 |                   
  crud.route.factory.ts            |   97.14 |    92.85 |   97.43 |   97.74 | 68,164,321        
  crud.service.ts                  |   95.91 |    88.76 |   97.14 |   95.83 | 42,208,221,271    
  override.decorator.ts            |     100 |      100 |     100 |     100 |                   
  util.ts                          |     100 |      100 |     100 |     100 |                   
 src/lib/abstract                  |     100 |       88 |     100 |     100 |                   
  abstract.request.interceptor.ts  |     100 |       88 |     100 |     100 | 45-53             
  crud.abstract.service.ts         |     100 |      100 |     100 |     100 |                   
  index.ts                         |     100 |      100 |     100 |     100 |                   
 src/lib/dto                       |     100 |    91.66 |     100 |     100 |                   
  pagination-cursor.dto.ts         |     100 |      100 |     100 |     100 |                   
  pagination-offset.dto.ts         |     100 |      100 |     100 |     100 |                   
  params.dto.ts                    |     100 |      100 |     100 |     100 |                   
  request-fields.dto.ts            |     100 |      100 |     100 |     100 |                   
  request-search.dto.ts            |     100 |      100 |     100 |     100 |                   
  request.dto.ts                   |     100 |    83.33 |     100 |     100 | 21                
 src/lib/interceptor               |   98.87 |    90.37 |     100 |   98.84 |                   
  create-request.interceptor.ts    |     100 |      100 |     100 |     100 |                   
  custom-request.interceptor.ts    |     100 |      100 |     100 |     100 |                   
  delete-request.interceptor.ts    |     100 |    95.45 |     100 |     100 | 26                
  index.ts                         |     100 |      100 |     100 |     100 |                   
  read-many-request.interceptor.ts |     100 |    93.06 |     100 |     100 | 28,48-55,106      
  read-one-request.interceptor.ts  |     100 |    92.77 |     100 |     100 | 32,54-56,69,85    
  recover-request.interceptor.ts   |     100 |       75 |     100 |     100 | 19                
  search-request.interceptor.ts    |   96.61 |     87.8 |     100 |   96.52 | 93,96,202-203     
  update-request.interceptor.ts    |     100 |    84.61 |     100 |     100 | 40,44             
  upsert-request.interceptor.ts    |     100 |    85.71 |     100 |     100 | 28,59,63          
 src/lib/interface                 |     100 |      100 |     100 |     100 |                   
  decorator-option.interface.ts    |     100 |      100 |     100 |     100 |                   
  index.ts                         |     100 |      100 |     100 |     100 |                   
  method.ts                        |     100 |      100 |     100 |     100 |                   
  pagination.interface.ts          |     100 |      100 |     100 |     100 |                   
  query-operation.interface.ts     |     100 |      100 |     100 |     100 |                   
  request.interface.ts             |     100 |      100 |     100 |     100 |                   
  sort.ts                          |     100 |      100 |     100 |     100 |                   
 src/lib/provider                  |     100 |      100 |     100 |     100 |                   
  crud-logger.ts                   |     100 |      100 |     100 |     100 |                   
  index.ts                         |     100 |      100 |     100 |     100 |                   
  pagination.helper.ts             |     100 |      100 |     100 |     100 |                   
  typeorm-query-builder.helper.ts  |     100 |      100 |     100 |     100 |                   
-----------------------------------|---------|----------|---------|---------|-------------------
Test Suites: 75 passed, 75 total
Tests:       226 passed, 226 total
Snapshots:   0 total
Time:        96.844 s, estimated 110 s
Ran all test suites.
✨  Done in 98.80s.
```

### AS-IS
```
----------------------------------------------------|---------|----------|---------|---------|-------------------
File                                                | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------------------------------------------------|---------|----------|---------|---------|-------------------
All files                                           |   98.55 |    91.32 |   97.52 |   98.55 |                   
 spec                                               |   96.72 |    82.35 |     100 |   96.66 |                   
  crud.abstract.entity.ts                           |     100 |      100 |     100 |     100 |                   
  dynamic-crud.module.ts                            |     100 |      100 |     100 |     100 |                   
  test.helper.ts                                    |   94.11 |       80 |     100 |   94.11 | 38,79             
 spec/auth-guard                                    |     100 |      100 |     100 |     100 |                   
  auth-guard.controller.ts                          |     100 |      100 |     100 |     100 |                   
  auth-guard.module.ts                              |     100 |      100 |     100 |     100 |                   
  auth.guard.ts                                     |     100 |      100 |     100 |     100 |                   
 spec/author                                        |     100 |      100 |     100 |     100 |                   
  author-object.interceptor.ts                      |     100 |      100 |     100 |     100 |                   
  author-object.module.ts                           |     100 |      100 |     100 |     100 |                   
  author-value.module.ts                            |     100 |      100 |     100 |     100 |                   
  author.interceptor.ts                             |     100 |      100 |     100 |     100 |                   
  author.module.ts                                  |     100 |      100 |     100 |     100 |                   
 spec/base                                          |     100 |      100 |     100 |     100 |                   
  base.controller.ts                                |     100 |      100 |     100 |     100 |                   
  base.entity.ts                                    |     100 |      100 |     100 |     100 |                   
  base.module.ts                                    |     100 |      100 |     100 |     100 |                   
  base.service.ts                                   |     100 |      100 |     100 |     100 |                   
 spec/custom-entity                                 |     100 |      100 |     100 |     100 |                   
  custom-entity.controller.ts                       |     100 |      100 |     100 |     100 |                   
  custom-entity.entity.ts                           |     100 |      100 |     100 |     100 |                   
  custom-entity.module.ts                           |     100 |      100 |     100 |     100 |                   
  custom-entity.service.ts                          |     100 |      100 |     100 |     100 |                   
 spec/custom-swagger-decorator                      |     100 |      100 |     100 |     100 |                   
  extra-model.ts                                    |     100 |      100 |     100 |     100 |                   
 spec/exclude-swagger                               |     100 |      100 |     100 |     100 |                   
  custom-response.dto.ts                            |     100 |      100 |     100 |     100 |                   
  exclude-swagger.controller.ts                     |     100 |      100 |     100 |     100 |                   
  exclude-swagger.module.ts                         |     100 |      100 |     100 |     100 |                   
 spec/multiple-primary-key                          |     100 |      100 |     100 |     100 |                   
  multiple-primary-key.controller.ts                |     100 |      100 |     100 |     100 |                   
  multiple-primary-key.entity.ts                    |     100 |      100 |     100 |     100 |                   
  multiple-primary-key.module.ts                    |     100 |      100 |     100 |     100 |                   
  multiple-primary-key.service.ts                   |     100 |      100 |     100 |     100 |                   
 spec/override-decorator                            |   69.23 |      100 |       0 |   72.72 |                   
  duplicated-override.controller.ts                 |   69.23 |      100 |       0 |   72.72 | 14,18,23          
 spec/pagination                                    |     100 |       75 |     100 |     100 |                   
  pagination.module.ts                              |     100 |       75 |     100 |     100 | 12-21             
  read-many.request.interceptor.ts                  |     100 |      100 |     100 |     100 |                   
 spec/param-option                                  |     100 |       75 |     100 |     100 |                   
  params.interceptor.ts                             |     100 |       75 |     100 |     100 | 10                
 spec/read-many                                     |     100 |      100 |     100 |     100 |                   
  number-of-take.controller.ts                      |     100 |      100 |     100 |     100 |                   
  read-many.module.ts                               |     100 |      100 |     100 |     100 |                   
  sort-asc.controller.ts                            |     100 |      100 |     100 |     100 |                   
  sort-desc.controller.ts                           |     100 |      100 |     100 |     100 |                   
 spec/relation-entities                             |     100 |      100 |     100 |     100 |                   
  category.entity.ts                                |     100 |      100 |     100 |     100 |                   
  category.service.ts                               |     100 |      100 |     100 |     100 |                   
  comment-relation.interceptor.ts                   |     100 |      100 |     100 |     100 |                   
  comment.entity.ts                                 |     100 |      100 |     100 |     100 |                   
  comment.service.ts                                |     100 |      100 |     100 |     100 |                   
  question.entity.ts                                |     100 |      100 |     100 |     100 |                   
  question.service.ts                               |     100 |      100 |     100 |     100 |                   
  relation-entities.module.ts                       |     100 |      100 |     100 |     100 |                   
  writer.entity.ts                                  |     100 |      100 |     100 |     100 |                   
  writer.service.ts                                 |     100 |      100 |     100 |     100 |                   
 spec/request-interceptor                           |     100 |      100 |     100 |     100 |                   
  delete.request.interceptor.ts                     |     100 |      100 |     100 |     100 |                   
  read-many.request.interceptor.ts                  |     100 |      100 |     100 |     100 |                   
  read-one.request.interceptor.ts                   |     100 |      100 |     100 |     100 |                   
  request-interceptor.controller.ts                 |     100 |      100 |     100 |     100 |                   
  request-interceptor.module.ts                     |     100 |      100 |     100 |     100 |                   
 spec/reserved-words                                |   66.66 |      100 |       0 |   71.42 |                   
  reserved-name.controller.ts                       |   66.66 |      100 |       0 |   71.42 | 13-16             
 spec/response-interceptor                          |   96.29 |    66.66 |     100 |   95.23 |                   
  response-custom.interceptor.ts                    |      90 |    66.66 |     100 |    87.5 | 11                
  response-interceptor.controller.ts                |     100 |      100 |     100 |     100 |                   
  response-interceptor.module.ts                    |     100 |      100 |     100 |     100 |                   
 spec/search                                        |     100 |      100 |     100 |     100 |                   
  module.ts                                         |     100 |      100 |     100 |     100 |                   
 spec/search-json-column                            |     100 |      100 |     100 |     100 |                   
  fixture.ts                                        |     100 |      100 |     100 |     100 |                   
  json.module.ts                                    |     100 |      100 |     100 |     100 |                   
  jsonb.module.ts                                   |     100 |      100 |     100 |     100 |                   
 spec/soft-delete-and-recover                       |     100 |      100 |     100 |     100 |                   
  delete-and-get-soft-deleted.controller.ts         |     100 |      100 |     100 |     100 |                   
  delete-and-ignore-soft-deleted.controller.ts      |     100 |      100 |     100 |     100 |                   
  soft-delete-and-get-soft-deleted.controller.ts    |     100 |      100 |     100 |     100 |                   
  soft-delete-and-ignore-soft-deleted.controller.ts |     100 |      100 |     100 |     100 |                   
  soft-delete-and-recover.module.ts                 |     100 |      100 |     100 |     100 |                   
 spec/sub-path                                      |     100 |      100 |     100 |     100 |                   
  depth-one.entity.ts                               |     100 |      100 |     100 |     100 |                   
  depth-one.service.ts                              |     100 |      100 |     100 |     100 |                   
  depth-two.entity.ts                               |     100 |      100 |     100 |     100 |                   
  depth-two.service.ts                              |     100 |      100 |     100 |     100 |                   
  sub-path.module.ts                                |     100 |      100 |     100 |     100 |                   
 spec/swagger-decorator                             |     100 |       80 |     100 |     100 |                   
  params.request.interceptor.ts                     |     100 |       80 |     100 |     100 | 10                
  swagger-decorator.controller.ts                   |     100 |      100 |     100 |     100 |                   
  swagger-decorator.module.ts                       |     100 |      100 |     100 |     100 |                   
 spec/unique-key                                    |     100 |      100 |     100 |     100 |                   
  unique.controller.ts                              |     100 |      100 |     100 |     100 |                   
  unique.entity.ts                                  |     100 |      100 |     100 |     100 |                   
  unique.module.ts                                  |     100 |      100 |     100 |     100 |                   
  unique.service.ts                                 |     100 |      100 |     100 |     100 |                   
 src                                                |     100 |      100 |     100 |     100 |                   
  index.ts                                          |     100 |      100 |     100 |     100 |                   
 src/lib                                            |   96.56 |    92.74 |   97.56 |   96.65 |                   
  constants.ts                                      |     100 |      100 |     100 |     100 |                   
  crud.decorator.ts                                 |     100 |      100 |     100 |     100 |                   
  crud.policy.ts                                    |     100 |      100 |     100 |     100 |                   
  crud.route.factory.ts                             |   97.14 |    92.85 |   97.43 |   97.74 | 68,164,321        
  crud.service.ts                                   |   92.85 |    86.51 |   94.28 |    92.7 | 38-46,208,221,271 
  override.decorator.ts                             |     100 |      100 |     100 |     100 |                   
  util.ts                                           |     100 |      100 |     100 |     100 |                   
 src/lib/abstract                                   |     100 |       88 |     100 |     100 |                   
  abstract.request.interceptor.ts                   |     100 |       88 |     100 |     100 | 45-53             
  crud.abstract.service.ts                          |     100 |      100 |     100 |     100 |                   
  index.ts                                          |     100 |      100 |     100 |     100 |                   
 src/lib/dto                                        |     100 |    91.66 |     100 |     100 |                   
  pagination-cursor.dto.ts                          |     100 |      100 |     100 |     100 |                   
  pagination-offset.dto.ts                          |     100 |      100 |     100 |     100 |                   
  params.dto.ts                                     |     100 |      100 |     100 |     100 |                   
  request-fields.dto.ts                             |     100 |      100 |     100 |     100 |                   
  request-search.dto.ts                             |     100 |      100 |     100 |     100 |                   
  request.dto.ts                                    |     100 |    83.33 |     100 |     100 | 21                
 src/lib/interceptor                                |   98.87 |    90.37 |     100 |   98.84 |                   
  create-request.interceptor.ts                     |     100 |      100 |     100 |     100 |                   
  custom-request.interceptor.ts                     |     100 |      100 |     100 |     100 |                   
  delete-request.interceptor.ts                     |     100 |    95.45 |     100 |     100 | 26                
  index.ts                                          |     100 |      100 |     100 |     100 |                   
  read-many-request.interceptor.ts                  |     100 |    93.06 |     100 |     100 | 28,48-55,106      
  read-one-request.interceptor.ts                   |     100 |    92.77 |     100 |     100 | 32,54-56,69,85    
  recover-request.interceptor.ts                    |     100 |       75 |     100 |     100 | 19                
  search-request.interceptor.ts                     |   96.61 |     87.8 |     100 |   96.52 | 93,96,202-203     
  update-request.interceptor.ts                     |     100 |    84.61 |     100 |     100 | 40,44             
  upsert-request.interceptor.ts                     |     100 |    85.71 |     100 |     100 | 28,59,63          
 src/lib/interface                                  |     100 |      100 |     100 |     100 |                   
  decorator-option.interface.ts                     |     100 |      100 |     100 |     100 |                   
  index.ts                                          |     100 |      100 |     100 |     100 |                   
  method.ts                                         |     100 |      100 |     100 |     100 |                   
  pagination.interface.ts                           |     100 |      100 |     100 |     100 |                   
  query-operation.interface.ts                      |     100 |      100 |     100 |     100 |                   
  request.interface.ts                              |     100 |      100 |     100 |     100 |                   
  sort.ts                                           |     100 |      100 |     100 |     100 |                   
 src/lib/provider                                   |     100 |      100 |     100 |     100 |                   
  crud-logger.ts                                    |     100 |      100 |     100 |     100 |                   
  index.ts                                          |     100 |      100 |     100 |     100 |                   
  pagination.helper.ts                              |     100 |      100 |     100 |     100 |                   
  typeorm-query-builder.helper.ts                   |     100 |      100 |     100 |     100 |                   
----------------------------------------------------|---------|----------|---------|---------|-------------------
Test Suites: 75 passed, 75 total
Tests:       226 passed, 226 total
Snapshots:   0 total
Time:        109.705 s
Ran all test suites.
✨  Done in 111.40s.
```