### PR TITLE
test: use 'toBeDefined' or 'toBeUndefined' without 'not' modifier

### DIFF
--- a/spec/relation-entities/relation-entities-disable-relations.spec.ts
+++ b/spec/relation-entities/relation-entities-disable-relations.spec.ts
@@ -67,9 +67,9 @@ describe('disable relation option', () => {
             .expect(HttpStatus.OK);
 
         for (const comment of commentListBody.data) {
-            expect(comment.writer).not.toBeDefined();
+            expect(comment.writer).toBeUndefined();
             const { body: commentBody } = await request(app.getHttpServer()).get(`/comment/${comment.id}`).expect(HttpStatus.OK);
-            expect(commentBody.writer).not.toBeDefined();
+            expect(commentBody.writer).toBeUndefined();
         }
     });
 });

--- a/spec/relation-entities/relation-entities-interceptor.spec.ts
+++ b/spec/relation-entities/relation-entities-interceptor.spec.ts
@@ -70,7 +70,7 @@ describe('relation interceptor', () => {
             if (comment.id % 2 === 0) {
                 expect(commentBody.writer).toBeDefined();
             } else {
-                expect(commentBody.writer).not.toBeDefined();
+                expect(commentBody.writer).toBeUndefined();
             }
         }
     });

--- a/spec/relation-entities/relation-entities-seleted-relations.spec.ts
+++ b/spec/relation-entities/relation-entities-seleted-relations.spec.ts
@@ -62,7 +62,7 @@ describe('disable relation option', () => {
 
             const { body: questionBody } = await request(app.getHttpServer()).get(`/question/${questionData.id}`).expect(HttpStatus.OK);
             expect(questionBody.writer).toBeDefined();
-            expect(questionBody.category).not.toBeDefined();
+            expect(questionBody.category).toBeUndefined();
         }
     });
 });

--- a/src/lib/crud.service.spec.ts
+++ b/src/lib/crud.service.spec.ts
@@ -19,7 +19,7 @@ describe('CrudService', () => {
         });
 
         it('should be defined', () => {
-            expect(crudService).not.toBeUndefined();
+            expect(crudService).toBeDefined();
         });
 
         it('should return entity', async () => {
@@ -38,7 +38,7 @@ describe('CrudService', () => {
         const crudService = new CrudService<BaseEntity>(mockRepository as unknown as Repository<BaseEntity>);
 
         it('should be defined', () => {
-            expect(crudService).not.toBeUndefined();
+            expect(crudService).toBeDefined();
         });
 
         it('should not be delete entity, when primary keys not exists ', async () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [x] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

I noticed a mix of 'toBeDefined' and 'not.toBeUndefined', as well as 'toBeUndefined' and 'not.toBeUndefined', within the codebase. I updated the code to use a consistent format that doesn't include the 'not' modifier.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
