### PR TITLE
Feature/fix read many swagger query

### DIFF
--- a/spec/base/base.controller.swagger.spec.ts
+++ b/spec/base/base.controller.swagger.spec.ts
@@ -67,7 +67,7 @@ describe('BaseController Swagger Decorator', () => {
         expect(routeSet[readMany].root?.method).toEqual('get');
         expect(routeSet[readMany].root?.summary).toEqual("read many from 'Base' Table");
         expect(routeSet[readMany].root?.description).toEqual("Fetch multiple entities in 'Base' Table");
-        expect(routeSet[readMany].root?.parameters).toHaveLength(2);
+        expect(routeSet[readMany].root?.parameters).toHaveLength(4);
         expect(routeSet[readMany].root?.parameters).toEqual(
             expect.arrayContaining([
                 {
@@ -77,6 +77,31 @@ describe('BaseController Swagger Decorator', () => {
                     description: 'Query parameters for Cursor Pagination',
                     schema: { type: 'string' },
                 },
+                {
+                    name: 'name',
+                    in: 'query',
+                    required: false,
+                    description: 'Query string filter by BaseEntity.name',
+                    schema: { type: 'string' },
+                },
+                {
+                    name: 'type',
+                    in: 'query',
+                    required: false,
+                    description: 'Query string filter by BaseEntity.type',
+                    schema: { type: 'string' },
+                },
+                {
+                    name: 'description',
+                    in: 'query',
+                    required: false,
+                    description: 'Query string filter by BaseEntity.description',
+                    schema: { type: 'string' },
+                },
+            ]),
+        );
+        expect(routeSet[readMany].root?.parameters).not.toEqual(
+            expect.arrayContaining([
                 {
                     name: 'query',
                     in: 'query',

--- a/src/lib/crud.route.factory.ts
+++ b/src/lib/crud.route.factory.ts
@@ -1,13 +1,13 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import { ExecutionContext, HttpStatus, Type } from '@nestjs/common';
 import {
-    INTERCEPTORS_METADATA,
     CUSTOM_ROUTE_ARGS_METADATA,
-    PATH_METADATA,
-    METHOD_METADATA,
-    ROUTE_ARGS_METADATA,
-    PARAMTYPES_METADATA,
     HTTP_CODE_METADATA,
+    INTERCEPTORS_METADATA,
+    METHOD_METADATA,
+    PARAMTYPES_METADATA,
+    PATH_METADATA,
+    ROUTE_ARGS_METADATA,
 } from '@nestjs/common/constants';
 import { DECORATORS } from '@nestjs/swagger/dist/constants';
 import { BaseEntity, getMetadataArgsStorage } from 'typeorm';
@@ -16,22 +16,22 @@ import { MetadataUtils } from 'typeorm/metadata-builder/MetadataUtils';
 import { CRUD_ROUTE_ARGS, OVERRIDE_METHOD_METADATA } from './constants';
 import { CRUD_POLICY } from './crud.policy';
 import { RequestSearchDto } from './dto/request-search.dto';
-import { CreateRequestDto } from './dto/request.dto';
+import { CreateRequestDto, getPropertyNamesFromMetadata } from './dto/request.dto';
 import {
-    CrudOptions,
-    Method,
-    CrudReadManyRequest,
-    CrudReadOneRequest,
-    CrudSearchRequest,
-    CrudUpdateOneRequest,
+    Column,
     CrudCreateRequest,
     CrudDeleteOneRequest,
-    PrimaryKey,
-    Column,
+    CrudOptions,
+    CrudReadManyRequest,
+    CrudReadOneRequest,
     CrudRecoverRequest,
+    CrudSearchRequest,
+    CrudUpdateOneRequest,
+    FactoryOption,
+    Method,
     PaginationType,
     PAGINATION_SWAGGER_QUERY,
-    FactoryOption,
+    PrimaryKey,
 } from './interface';
 import { CrudLogger } from './provider/crud-logger';
 import { capitalizeFirstLetter, isSomeEnum } from './util';
@@ -257,6 +257,13 @@ export class CrudRouteFactory {
                     in: 'query',
                     required: false,
                     description: `Query parameters for ${capitalizeFirstLetter(this.paginationType)} Pagination`,
+                })),
+                ...getPropertyNamesFromMetadata(this.crudOptions.entity, method).map((property) => ({
+                    name: property,
+                    type: 'string',
+                    in: 'query',
+                    required: false,
+                    description: `Query string filter by ${this.crudOptions.entity.name}.${property}`,
                 })),
             );
         }

--- a/src/lib/interface/pagination.interface.ts
+++ b/src/lib/interface/pagination.interface.ts
@@ -10,12 +10,8 @@ export const PAGINATION_SWAGGER_QUERY: Record<PaginationType, Array<{ name: stri
     [PaginationType.OFFSET]: [
         { name: 'limit', type: 'integer' },
         { name: 'offset', type: 'integer' },
-        { name: 'query', type: 'string' },
     ],
-    [PaginationType.CURSOR]: [
-        { name: 'nextCursor', type: 'string' },
-        { name: 'query', type: 'string' },
-    ],
+    [PaginationType.CURSOR]: [{ name: 'nextCursor', type: 'string' }],
 };
 
 export interface PaginationRequestAbstract {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There is a small point we can improve regarding to open API(swagger) generation.

Currently, there is `query` in query parameter for ReadMany Method of open API document which cannot fully convey our ReadMany method.

For example, this is how it looks when I copy curl command directly from auto-generated swagger.

```sh
curl -X 'GET'  'http://localhost:3000/base?query=name%3Dfoo'  -H 'accept: application/json'
```

Actually, `ReadManyRequestInterceptor` is expecting each field of entity to be passed with query string as below.

```sh
curl -X 'GET'  'http://localhost:3000/base?name=foo&type=bar'  -H 'accept: application/json'
```

Issue Number: N/A

## What is the new behavior?

In order to support more accurate open API document, make query parameters of ReadMany method based on class-validator's metadata as we use them in creating DTO for Create/Update method.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
