### PR TITLE
feat: [proposal] allow to customize service method for each controller's route

### DIFF
--- a/spec/custom-service/custom-service.controller.spec.ts
+++ b/spec/custom-service/custom-service.controller.spec.ts
@@ -1,0 +1,68 @@
+import { HttpStatus, INestApplication, forwardRef } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import request from 'supertest';
+
+import { CustomServiceController } from './custom-service.controller';
+import { CustomServiceService } from './custom-service.service';
+import { BaseEntity } from '../base/base.entity';
+import { TestHelper } from '../test.helper';
+
+describe('Custom Service', () => {
+    let app: INestApplication;
+
+    beforeEach(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [forwardRef(() => TestHelper.getTypeOrmMysqlModule([BaseEntity])), TypeOrmModule.forFeature([BaseEntity])],
+            controllers: [CustomServiceController],
+            providers: [CustomServiceService],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+
+        await app.init();
+    });
+
+    afterEach(async () => {
+        await TestHelper.dropTypeOrmEntityTables();
+        await app?.close();
+    });
+
+    it('should invoke override method in service', async () => {
+        const routerPathList = TestHelper.getRoutePath(app.getHttpServer());
+        expect(routerPathList.post).toEqual(expect.arrayContaining(['/test']));
+        expect(routerPathList.delete).toEqual(expect.arrayContaining(['/test/:id']));
+
+        let response = await request(app.getHttpServer()).post('/test').send({ name: 'test' });
+
+        expect(response.statusCode).toEqual(HttpStatus.CREATED);
+        expect(response.body.result).toEqual('ok');
+        expect(response.body.payload).toBeDefined();
+        expect(response.body.payload.body.name).toEqual('test');
+
+        response = await request(app.getHttpServer()).delete('/test/1').send();
+
+        expect(response.statusCode).toEqual(HttpStatus.OK);
+        expect(response.body.result).toEqual('ok');
+        expect(response.body.payload).toBeDefined();
+        expect(response.body.payload.params.id).toEqual(1);
+    });
+
+    it('should invoke default method if non override', async () => {
+        const routerPathList = TestHelper.getRoutePath(app.getHttpServer());
+        expect(routerPathList.patch).toEqual(expect.arrayContaining(['/test/:id']));
+
+        const response = await request(app.getHttpServer()).patch('/test/1').send({});
+
+        expect(response.statusCode).toEqual(HttpStatus.NOT_FOUND);
+    });
+
+    it('should invoke default method if using wrong method', async () => {
+        const routerPathList = TestHelper.getRoutePath(app.getHttpServer());
+        expect(routerPathList.get).toEqual(expect.arrayContaining(['/test/:id']));
+
+        const response = await request(app.getHttpServer()).get('/test/1').send();
+
+        expect(response.statusCode).toEqual(HttpStatus.NOT_FOUND);
+    });
+});

--- a/spec/custom-service/custom-service.controller.ts
+++ b/spec/custom-service/custom-service.controller.ts
@@ -1,0 +1,26 @@
+import { Controller } from '@nestjs/common';
+
+import { CustomServiceService } from './custom-service.service';
+import { Crud } from '../../src/lib/crud.decorator';
+import { CrudController, Method } from '../../src/lib/interface';
+import { BaseEntity } from '../base/base.entity';
+
+@Crud({
+    entity: BaseEntity,
+    only: [Method.CREATE, Method.UPDATE, Method.READ_ONE, Method.DELETE],
+    routes: {
+        create: {
+            serviceMethod: 'newCreate',
+        },
+        readOne: {
+            serviceMethod: 'wrongMethod',
+        },
+        delete: {
+            serviceMethod: 'newDelete',
+        },
+    },
+})
+@Controller('test')
+export class CustomServiceController implements CrudController<BaseEntity> {
+    constructor(public readonly crudService: CustomServiceService) {}
+}

--- a/spec/custom-service/custom-service.service.ts
+++ b/spec/custom-service/custom-service.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { CrudService } from '../../src/lib/crud.service';
+import { CrudCreateRequest, CrudDeleteOneRequest } from '../../src/lib/interface/request.interface';
+import { BaseEntity } from '../base/base.entity';
+
+@Injectable()
+export class CustomServiceService extends CrudService<BaseEntity> {
+    constructor(@InjectRepository(BaseEntity) repository: Repository<BaseEntity>) {
+        super(repository);
+    }
+
+    newCreate(params: CrudCreateRequest<BaseEntity>) {
+        return {
+            payload: params,
+            result: 'ok',
+        };
+    }
+
+    newDelete(params: CrudDeleteOneRequest<BaseEntity>) {
+        return {
+            payload: params,
+            result: 'ok',
+        };
+    }
+}

--- a/src/lib/crud.route.factory.ts
+++ b/src/lib/crud.route.factory.ts
@@ -103,49 +103,81 @@ export class CrudRouteFactory {
     }
 
     protected readOne<T>(controllerMethodName: string) {
+        const serviceMethod = this.crudOptions.routes?.[Method.READ_ONE]?.serviceMethod;
         this.targetPrototype[controllerMethodName] = function reservedReadOne(crudReadOneRequest: CrudReadOneRequest<T>) {
+            if (serviceMethod && this.crudService[serviceMethod] && typeof this.crudService[serviceMethod] === 'function') {
+                return this.crudService[serviceMethod](crudReadOneRequest);
+            }
             return this.crudService.reservedReadOne(crudReadOneRequest);
         };
     }
 
     protected readMany<T>(controllerMethodName: string) {
+        const serviceMethod = this.crudOptions.routes?.[Method.READ_MANY]?.serviceMethod;
         this.targetPrototype[controllerMethodName] = function reservedReadMany(crudReadManyRequest: CrudReadManyRequest<T>) {
+            if (serviceMethod && this.crudService[serviceMethod] && typeof this.crudService[serviceMethod] === 'function') {
+                return this.crudService[serviceMethod](crudReadManyRequest);
+            }
             return this.crudService.reservedReadMany(crudReadManyRequest);
         };
     }
 
     protected search<T>(controllerMethodName: string) {
+        const serviceMethod = this.crudOptions.routes?.[Method.SEARCH]?.serviceMethod;
         this.targetPrototype[controllerMethodName] = function reservedSearch(crudSearchRequest: CrudSearchRequest<T>) {
+            if (serviceMethod && this.crudService[serviceMethod] && typeof this.crudService[serviceMethod] === 'function') {
+                return this.crudService[serviceMethod](crudSearchRequest);
+            }
             return this.crudService.reservedSearch(crudSearchRequest);
         };
     }
 
     protected create<T>(controllerMethodName: string) {
+        const serviceMethod = this.crudOptions.routes?.[Method.CREATE]?.serviceMethod;
         this.targetPrototype[controllerMethodName] = function reservedCreate(crudCreateRequest: CrudCreateRequest<T>) {
+            if (serviceMethod && this.crudService[serviceMethod] && typeof this.crudService[serviceMethod] === 'function') {
+                return this.crudService[serviceMethod](crudCreateRequest);
+            }
             return this.crudService.reservedCreate(crudCreateRequest);
         };
     }
 
     protected upsert<T>(controllerMethodName: string) {
+        const serviceMethod = this.crudOptions.routes?.[Method.UPSERT]?.serviceMethod;
         this.targetPrototype[controllerMethodName] = function reservedUpsert(crudCreateRequest: CrudCreateRequest<T>) {
+            if (serviceMethod && this.crudService[serviceMethod] && typeof this.crudService[serviceMethod] === 'function') {
+                return this.crudService[serviceMethod](crudCreateRequest);
+            }
             return this.crudService.reservedUpsert(crudCreateRequest);
         };
     }
 
     protected update<T>(controllerMethodName: string) {
+        const serviceMethod = this.crudOptions.routes?.[Method.UPDATE]?.serviceMethod;
         this.targetPrototype[controllerMethodName] = function reservedUpdate(crudUpdateOneRequest: CrudUpdateOneRequest<T>) {
+            if (serviceMethod && this.crudService[serviceMethod] && typeof this.crudService[serviceMethod] === 'function') {
+                return this.crudService[serviceMethod](crudUpdateOneRequest);
+            }
             return this.crudService.reservedUpdate(crudUpdateOneRequest);
         };
     }
 
     protected delete<T>(controllerMethodName: string) {
+        const serviceMethod = this.crudOptions.routes?.[Method.DELETE]?.serviceMethod;
         this.targetPrototype[controllerMethodName] = function reservedDelete(crudDeleteOneRequest: CrudDeleteOneRequest<T>) {
+            if (serviceMethod && this.crudService[serviceMethod] && typeof this.crudService[serviceMethod] === 'function') {
+                return this.crudService[serviceMethod](crudDeleteOneRequest);
+            }
             return this.crudService.reservedDelete(crudDeleteOneRequest);
         };
     }
 
     protected recover<T>(controllerMethodName: string) {
+        const serviceMethod = this.crudOptions.routes?.[Method.RECOVER]?.serviceMethod;
         this.targetPrototype[controllerMethodName] = function reservedRecover(crudRecoverRequest: CrudRecoverRequest<T>) {
+            if (serviceMethod && this.crudService[serviceMethod] && typeof this.crudService[serviceMethod] === 'function') {
+                return this.crudService[serviceMethod](crudRecoverRequest);
+            }
             return this.crudService.reservedRecover(crudRecoverRequest);
         };
     }

--- a/src/lib/interface/decorator-option.interface.ts
+++ b/src/lib/interface/decorator-option.interface.ts
@@ -25,6 +25,11 @@ interface RouteBaseOption {
          */
         response?: Type<unknown>;
     };
+    /**
+     * Configure the service's method will be executed in controller's logic.
+     * If omitted or set to non-existed method, default method will be used.
+     */
+    serviceMethod?: string;
 }
 
 export interface PrimaryKey {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

For now, controller routes will execute the pre-defined logic in the service class. But sometimes, we may need to customize the behavior of logic which cannot be done with interceptors.

## What is the new behavior?

Allow to set up the `serviceMethod` for each route. This field indicates the name of the method that will be executed inside the corresponding controller's route.
If `serviceMethod` is not defined or identifies a wrong method, the existing built-in method will be used instead, just like the current behavior.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
