### PR TITLE
Feature: Allow to use standard interceptor in override route

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@
     </a>
     <a href="https://www.npmjs.com/package/@nestjs-library/crud">
         <img src="https://img.shields.io/npm/dw/@nestjs-library/crud">
-    </a>        
+    </a>
 </p>
 
 <p align="center">
     <a href="./README.md">
         <span>English<span>
-    </a> 
+    </a>
     <span>|</span>
     <a href="./README.ko.md">
         <span>한국어<span>
-    </a> 
+    </a>
 </p>
 
 This is a Typescript library that provides a NestJS decorator which automatically generates CRUD routes of a controller for given TypeORM entity. The decorator generates endpoints for not only create, retrieve one, retrieve many, update, delete but also upsert, recover and search operations for the entity.
@@ -158,7 +158,7 @@ import { NestInterceptor, Type } from '@nestjs/common';
 
 interface RouteBaseOption {
     decorators?: Array<PropertyDecorator | MethodDecorator>;
-    interceptors?: Array<Type<NestInterceptor>>;
+    interceptors?: Array<Type<NestInterceptor> | ((crudOptions: CrudOptions, factoryOption: FactoryOption) => Type<NestInterceptor>)>;
     swagger?: {
         hide?: boolean;
         response?: Type<unknown>;

--- a/lint-staged.config.cjs
+++ b/lint-staged.config.cjs
@@ -1,4 +1,4 @@
 module.exports = {
     '*.+(ts|js|json)': ['eslint --ext .ts,.js --fix', 'prettier --write'],
-    '*.+(ts)': [() => 'tsc -p tsconfig.lib.json --noEmit', () => 'tsc -p tsconfig.spec.json --noEmit'],
+    '*.+(ts)': [() => 'tsc -p tsconfig.cjs.json --noEmit', () => 'tsc -p tsconfig.spec.json --noEmit'],
 };

--- a/spec/override-decorator/add-current-time.interceptor.ts
+++ b/spec/override-decorator/add-current-time.interceptor.ts
@@ -1,0 +1,13 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import { Observable } from 'rxjs';
+
+import { CRUD_ROUTE_ARGS } from '../../src';
+
+@Injectable()
+export class AddCurrentTimeInterceptor implements NestInterceptor {
+    intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+        const req = context.switchToHttp().getRequest();
+        req[CRUD_ROUTE_ARGS].body.time = Date.now();
+        return next.handle();
+    }
+}

--- a/spec/override-decorator/override.create.controller.spec.ts
+++ b/spec/override-decorator/override.create.controller.spec.ts
@@ -38,6 +38,26 @@ describe('OverrideDecorator for CREATE', () => {
         expect(response.body.result).toEqual('createOne');
     });
 
+    it('should invoke override method with proper payload', async () => {
+        const routerPathList = TestHelper.getRoutePath(app.getHttpServer());
+        expect(routerPathList.patch).toEqual(expect.arrayContaining(['/test/:id']));
+
+        let response = await request(app.getHttpServer()).patch('/test/1').send({ type: 'string' });
+
+        expect(response.statusCode).toEqual(HttpStatus.UNPROCESSABLE_ENTITY);
+
+        response = await request(app.getHttpServer()).patch('/test/1').send({ name: 'string', type: 1 });
+
+        expect(response.statusCode).toEqual(HttpStatus.OK);
+        expect(response.body.result).toEqual('updateOne');
+        expect(response.body.params.id).toEqual(1);
+        expect(response.body.body.name).toEqual('string');
+        expect(response.body.body.type).toEqual(1);
+        expect(response.body.body.time).toEqual(expect.any(Number));
+        expect(response.body.author.property).toEqual('updatedBy');
+        expect(response.body.author.value).toEqual('user');
+    });
+
     it('should not invoke non override method', async () => {
         const routerPathList = TestHelper.getRoutePath(app.getHttpServer());
         expect(routerPathList.post).toEqual(expect.arrayContaining(['/test/search']));

--- a/spec/override-decorator/override.create.controller.ts
+++ b/spec/override-decorator/override.create.controller.ts
@@ -1,13 +1,25 @@
 import { Controller } from '@nestjs/common';
 
+import { AddCurrentTimeInterceptor } from './add-current-time.interceptor';
 import { Crud } from '../../src/lib/crud.decorator';
-import { CrudController } from '../../src/lib/interface';
+import { CrudRouteArgs } from '../../src/lib/crud.route.args.decorator';
+import { UpdateRequestInterceptor } from '../../src/lib/interceptor/update-request.interceptor';
+import { CrudController, CrudUpdateOneRequest } from '../../src/lib/interface';
 import { Override } from '../../src/lib/override.decorator';
 import { BaseEntity } from '../base/base.entity';
 import { BaseService } from '../base/base.service';
 
 @Crud({
     entity: BaseEntity,
+    routes: {
+        update: {
+            interceptors: [UpdateRequestInterceptor, AddCurrentTimeInterceptor],
+            author: {
+                property: 'updatedBy',
+                value: 'user',
+            },
+        },
+    },
 })
 @Controller('test')
 export class OverrideCreateController implements CrudController<BaseEntity> {
@@ -16,6 +28,11 @@ export class OverrideCreateController implements CrudController<BaseEntity> {
     @Override('CREATE')
     overrideCreate() {
         return { result: 'createOne' };
+    }
+
+    @Override('UPDATE')
+    overrideUpdate(@CrudRouteArgs() crudUpdateOneRequest: CrudUpdateOneRequest<BaseEntity>) {
+        return { ...crudUpdateOneRequest, result: 'updateOne' };
     }
 
     search() {

--- a/src/lib/crud.route.args.decorator.ts
+++ b/src/lib/crud.route.args.decorator.ts
@@ -1,0 +1,9 @@
+import { ExecutionContext, createParamDecorator } from '@nestjs/common';
+
+import { CRUD_ROUTE_ARGS } from './constants';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const CrudRouteArgs = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
+    const req = ctx.switchToHttp().getRequest();
+    return req[CRUD_ROUTE_ARGS];
+});

--- a/src/lib/crud.route.factory.ts
+++ b/src/lib/crud.route.factory.ts
@@ -10,6 +10,7 @@ import {
     ROUTE_ARGS_METADATA,
 } from '@nestjs/common/constants';
 import { DECORATORS } from '@nestjs/swagger/dist/constants';
+import _ from 'lodash';
 import { BaseEntity, getMetadataArgsStorage } from 'typeorm';
 import { MetadataUtils } from 'typeorm/metadata-builder/MetadataUtils';
 
@@ -176,7 +177,11 @@ export class CrudRouteFactory {
         Reflect.defineMetadata(
             INTERCEPTORS_METADATA,
             [
-                ...(this.crudOptions.routes?.[crudMethod]?.interceptors ?? []),
+                ...(this.crudOptions.routes?.[crudMethod]?.interceptors ?? []).map((interceptor) =>
+                    _.isFunction(interceptor) && !interceptor.toString().startsWith('class ')
+                        ? interceptor(this.crudOptions, factoryOption)
+                        : interceptor,
+                ),
                 isOverride ? undefined : CRUD_POLICY[crudMethod].interceptor(this.crudOptions, factoryOption),
             ].filter(Boolean),
             targetMethod,

--- a/src/lib/interface/decorator-option.interface.ts
+++ b/src/lib/interface/decorator-option.interface.ts
@@ -1,7 +1,7 @@
 import { NestInterceptor, Type } from '@nestjs/common';
 import { BaseEntity, ColumnType } from 'typeorm';
 
-import { Method, Sort, PaginationType, Author } from '.';
+import { Method, Sort, PaginationType, Author, FactoryOption } from '.';
 
 interface RouteBaseOption {
     /**
@@ -11,7 +11,7 @@ interface RouteBaseOption {
     /**
      * An array of interceptors to apply to the route handler
      */
-    interceptors?: Array<Type<NestInterceptor>>;
+    interceptors?: Array<Type<NestInterceptor> | ((crudOptions: CrudOptions, factoryOption: FactoryOption) => Type<NestInterceptor>)>;
     /**
      * Configures the Swagger documentation for the route
      */


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When we use `Override` decorator, all standard interceptors (to validate and transform payload) will not be used automatically. To overcome this, we need to replicate their logic.

Issue Number: N/A

## What is the new behavior?

- Allow to include the standard interceptor in `CrudOptions`.
- Detect the form of each interceptor. If it's function (which is standard interceptor), execute it. Otherwise, it's a class that implements `NestInterceptor`, just use it directly.
- Define new decorator `CrudRouteArgs` to allow overridden route can retrieve the transformed payload.

Then we can use both standard interceptors and new custom interceptors as below:
```
@Crud({
    entity: Entity,
    routes: {
        update: {
            interceptors: [
              UpdateRequestInterceptor,     // This is standard interceptor that will transform payload for UPDATE route.
              ModifyPayloadInterceptor,      // This is custom interceptor that will modify payload after transformed.
            ],
            author: {
                property: 'updatedBy',
                value: 'user',
            },
        },
    },
})
```

### FIX:
- Fix `pre-commit` script to use proper `tsconfig.mjs.json`

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
