### PR TITLE
feat: Officially support `total` in cursor pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nestjs-library/crud",
-    "version": "0.6.1",
+    "version": "0.6.3",
     "description": "Automatically generate CRUD Rest API based on NestJS and TypeOrm",
     "homepage": "https://github.com/woowabros/nestjs-library-crud",
     "repository": {

--- a/spec/logging/logging.spec.ts
+++ b/spec/logging/logging.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-classes-per-file */
-import { INestApplication, Logger } from '@nestjs/common';
+import { ConsoleLogger, INestApplication } from '@nestjs/common';
 import { Controller, Injectable, Module } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { InjectRepository, TypeOrmModule } from '@nestjs/typeorm';
@@ -13,7 +13,8 @@ import { CrudService } from '../../src/lib/crud.service';
 import { CrudController } from '../../src/lib/interface';
 import { TestHelper } from '../test.helper';
 
-const logger = new Logger();
+const logger = new ConsoleLogger();
+logger.setLogLevels(['error']);
 @Entity('test')
 class TestEntity extends BaseEntity {
     @PrimaryColumn()

--- a/spec/search/search-query-operator.spec.ts
+++ b/spec/search/search-query-operator.spec.ts
@@ -69,8 +69,7 @@ describe('Search Query Operator', () => {
 
             expect(metadata.nextCursor).toBeDefined();
             expect(metadata.query).toBeDefined();
-
-            expect(await service.getTotalCountByCrudSearchRequest({ requestSearchDto })).toEqual(10);
+            expect(metadata.total).toEqual(10);
         }
     });
 

--- a/src/lib/crud.policy.ts
+++ b/src/lib/crud.policy.ts
@@ -23,6 +23,22 @@ interface CrudMethodPolicy {
     };
     default?: Record<string, unknown>;
 }
+
+const metaProperties = (paginationType: PaginationType) =>
+    paginationType === PaginationType.OFFSET
+        ? {
+              page: { type: 'number', example: 1 },
+              pages: { type: 'number', example: 1 },
+              total: { type: 'number', example: 100 },
+              offset: { type: 'number', example: 20 },
+              query: { type: 'string', example: 'queryToken' },
+          }
+        : {
+              total: { type: 'number', example: 100 },
+              limit: { type: 'number', example: 20 },
+              query: { type: 'string', example: 'queryToken' },
+              nextCursor: { type: 'string', example: 'cursorToken' },
+          };
 /**
  * Basic Policy by method
  */
@@ -110,20 +126,6 @@ export const CRUD_POLICY: Record<Method, CrudMethodPolicy> = {
                 description: `Fetch multiple entities in '${capitalizeFirstLetter(tableName)}' Table`,
             }),
             responseMetadata: ({ type, tableName, paginationType }) => {
-                const metaProperties =
-                    paginationType === PaginationType.OFFSET
-                        ? {
-                              page: { type: 'number', example: 1 },
-                              pages: { type: 'number', example: 1 },
-                              total: { type: 'number', example: 100 },
-                              offset: { type: 'number', example: 20 },
-                              query: { type: 'string', example: 'queryToken' },
-                          }
-                        : {
-                              limit: { type: 'number', example: 20 },
-                              query: { type: 'string', example: 'queryToken' },
-                              nextCursor: { type: 'string', example: 'cursorToken' },
-                          };
                 return {
                     [HttpStatus.OK]: {
                         description: `Fetch many entities from ${capitalizeFirstLetter(tableName)} table`,
@@ -139,7 +141,7 @@ export const CRUD_POLICY: Record<Method, CrudMethodPolicy> = {
                                         },
                                         metadata: {
                                             type: 'object',
-                                            properties: metaProperties,
+                                            properties: metaProperties(paginationType),
                                         },
                                     },
                                 },

--- a/src/lib/dto/pagination-cursor.dto.ts
+++ b/src/lib/dto/pagination-cursor.dto.ts
@@ -9,7 +9,7 @@ export class PaginationCursorDto implements PaginationRequestAbstract {
     @Expose({ name: 'nextCursor' })
     @IsString()
     @IsOptional()
-    token?: string;
+    nextCursor?: string;
 
     @Expose({ name: 'query' })
     @IsString()

--- a/src/lib/interceptor/read-many-request.interceptor.spec.ts
+++ b/src/lib/interceptor/read-many-request.interceptor.spec.ts
@@ -37,7 +37,7 @@ describe('ReadManyRequestInterceptor', () => {
         const interceptor = new Interceptor();
 
         expect(interceptor.getPaginationRequest(PaginationType.CURSOR, { key: 'value', nextCursor: 'token' })).toEqual({
-            token: 'token',
+            nextCursor: 'token',
             type: 'cursor',
         });
     });

--- a/src/lib/interceptor/read-many-request.interceptor.ts
+++ b/src/lib/interceptor/read-many-request.interceptor.ts
@@ -35,7 +35,7 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
 
             const query = await (async () => {
                 if (
-                    (pagination.type === PaginationType.CURSOR && !_.isNil(pagination['token'])) ||
+                    (pagination.type === PaginationType.CURSOR && !_.isNil(pagination['nextCursor'])) ||
                     (pagination.type === PaginationType.OFFSET && (!_.isNil(pagination['offset']) || !_.isNil(pagination['limit'])))
                 ) {
                     return;
@@ -81,6 +81,7 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
             if (_.isNil(query)) {
                 return;
             }
+
             const transformed = plainToInstance(crudOptions.entity, query, { groups: [GROUP.READ_MANY] });
             const errorList = await validate(transformed, {
                 groups: [GROUP.READ_MANY],

--- a/src/lib/interface/pagination.interface.ts
+++ b/src/lib/interface/pagination.interface.ts
@@ -26,6 +26,7 @@ export interface CursorPaginationResponse<T> extends PaginationAbstractResponse<
     metadata: {
         query: string;
         limit: number;
+        total: number;
         nextCursor: string;
     };
 }

--- a/src/lib/provider/pagination.helper.ts
+++ b/src/lib/provider/pagination.helper.ts
@@ -5,12 +5,12 @@ export class PaginationHelper {
         return Buffer.from(JSON.stringify(entity)).toString(encoding);
     }
 
-    static deserialize<T>(token?: string): T {
-        if (!token) {
+    static deserialize<T>(nextCursor?: string): T {
+        if (!nextCursor) {
             return {} as T;
         }
         try {
-            return JSON.parse(Buffer.from(token, encoding).toString());
+            return JSON.parse(Buffer.from(nextCursor, encoding).toString());
         } catch {
             return {} as T;
         }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -2,5 +2,5 @@ export const capitalizeFirstLetter = (raw: string) => `${raw.charAt(0).toUpperCa
 
 export const isSomeEnum =
     <TEnum extends Record<string, unknown>>(enumType: TEnum) =>
-    (token: unknown): token is TEnum[keyof TEnum] =>
-        Object.values(enumType).includes(token as TEnum[keyof TEnum]);
+    (nextCursor: unknown): nextCursor is TEnum[keyof TEnum] =>
+        Object.values(enumType).includes(nextCursor as TEnum[keyof TEnum]);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Did not support `total` in cursor pagination.

When using cursor pagination, the request could not `check how many entities remained`.

Due to this requirement, we have provided `getTotalCountByCrudReadManyRequest` and `getTotalCountByCrudSearchRequest` in the service.

The CRUD library user used the method provided by the service by calling it(getTotalCount*) in the `response interceptor` and including it(total) in the response.

## What is the new behavior?

Officially support `total` in cursor pagination.

**The `method for total` is deprecated**
- getTotalCountByCrudReadManyRequest
- getTotalCountByCrudSearchRequest

## Does this PR introduce a breaking change?

-   [x] Yes
-   [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I am preparing to provide `offset pagination in the search` method as well.

For now, `pagination is complicating` the service. 
I will be `refactoring the pagination` related code before supporting offset pagination in search. 

This PR is the first of refactoring.