### PR TITLE
Separate the core functionality from the Request Interface and Response Interface in ReadMany

### DIFF
--- a/spec/logging/logging.spec.ts
+++ b/spec/logging/logging.spec.ts
@@ -79,21 +79,18 @@ describe('Logging', () => {
         await request(app.getHttpServer()).get('/base');
         expect(loggerSpy).toHaveBeenNthCalledWith(
             2,
-            {
-                sort: 'DESC',
-                pagination: {
-                    type: 'cursor',
+            JSON.stringify({
+                _primaryKeys: [{ name: 'col1', isPrimary: true }],
+                _findOptions: {
+                    where: {},
+                    take: 20,
+                    withDeleted: false,
+                    order: { col1: 'DESC' },
+                    relations: [],
                 },
-                numberOfTake: 20,
-                query: {},
-                primaryKeys: [
-                    {
-                        name: 'col1',
-                        isPrimary: true,
-                        type: expect.any(Function),
-                    },
-                ],
-            },
+                _pagination: { type: 'cursor' },
+                _sort: 'DESC',
+            }),
             'CRUD GET /base',
         );
 
@@ -105,6 +102,8 @@ describe('Logging', () => {
                     col1: '1',
                 },
                 fields: [],
+                relations: [],
+                softDeleted: expect.any(Boolean),
             },
             'CRUD GET /base/1',
         );

--- a/spec/pagination/pagination.module.ts
+++ b/spec/pagination/pagination.module.ts
@@ -9,7 +9,7 @@ import { TestHelper } from '../test.helper';
 
 export function PaginationModule(crudOptions?: Record<PaginationType, CrudOptions['routes']>) {
     function offsetController() {
-        @Crud({ entity: BaseEntity, routes: crudOptions?.[PaginationType.OFFSET] })
+        @Crud({ entity: BaseEntity, routes: crudOptions?.[PaginationType.OFFSET], logging: true })
         @Controller(`${PaginationType.OFFSET}`)
         class OffsetController implements CrudController<BaseEntity> {
             constructor(public readonly crudService: BaseService) {}
@@ -18,7 +18,7 @@ export function PaginationModule(crudOptions?: Record<PaginationType, CrudOption
     }
 
     function cursorController() {
-        @Crud({ entity: BaseEntity, routes: crudOptions?.[PaginationType.CURSOR] })
+        @Crud({ entity: BaseEntity, routes: crudOptions?.[PaginationType.CURSOR], logging: true })
         @Controller(`${PaginationType.CURSOR}`)
         class CursorController implements CrudController<BaseEntity> {
             constructor(public readonly crudService: BaseService) {}

--- a/spec/pagination/pagination.spec.ts
+++ b/spec/pagination/pagination.spec.ts
@@ -1,4 +1,4 @@
-import { HttpStatus, INestApplication } from '@nestjs/common';
+import { ConsoleLogger, HttpStatus, INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import _ from 'lodash';
 import request from 'supertest';
@@ -15,6 +15,8 @@ describe('Pagination', () => {
     const defaultLimit = 20;
 
     beforeEach(async () => {
+        const logger = new ConsoleLogger();
+        logger.setLogLevels(['error']);
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [
                 PaginationModule({
@@ -22,7 +24,9 @@ describe('Pagination', () => {
                     offset: { readMany: { paginationType: 'offset' } },
                 }),
             ],
-        }).compile();
+        })
+            .setLogger(logger)
+            .compile();
         app = moduleFixture.createNestApplication();
 
         service = moduleFixture.get<BaseService>(BaseService);

--- a/spec/read-many/number-of-take.controller.ts
+++ b/spec/read-many/number-of-take.controller.ts
@@ -8,6 +8,7 @@ import { BaseService } from '../base/base.service';
 @Crud({
     entity: BaseEntity,
     routes: { readMany: { numberOfTake: 10 } },
+    logging: true,
 })
 @Controller('take')
 export class NumberOfTakeController implements CrudController<BaseEntity> {

--- a/spec/read-many/sort-asc.controller.ts
+++ b/spec/read-many/sort-asc.controller.ts
@@ -8,6 +8,7 @@ import { BaseService } from '../base/base.service';
 @Crud({
     entity: BaseEntity,
     routes: { readMany: { sort: Sort.ASC } },
+    logging: true,
 })
 @Controller('sort-asc')
 export class SortAscController implements CrudController<BaseEntity> {

--- a/spec/read-many/sort-desc.controller.ts
+++ b/spec/read-many/sort-desc.controller.ts
@@ -8,6 +8,7 @@ import { BaseService } from '../base/base.service';
 @Crud({
     entity: BaseEntity,
     routes: { readMany: { sort: 'DESC' } },
+    logging: true,
 })
 @Controller('sort-desc')
 export class SortDescController implements CrudController<BaseEntity> {

--- a/spec/search-json-column/search-json.mysql.spec.ts
+++ b/spec/search-json-column/search-json.mysql.spec.ts
@@ -33,11 +33,13 @@ describe('Search JSON column - MySQL', () => {
         it('should search entities that meets operation for array column', async () => {
             const { data } = await service.reservedSearch({
                 requestSearchDto: { where: [{ friends: { operator: 'JSON_CONTAINS', operand: '{ "firstName": "Taylor" }' } }] },
+                relations: [],
             });
             expect(data).toHaveLength(1);
 
             const { data: data2 } = await service.reservedSearch({
                 requestSearchDto: { where: [{ friends: { operator: 'JSON_CONTAINS', operand: '{ "gender": "Male" }' } }] },
+                relations: [],
             });
             expect(data2).toHaveLength(2);
 
@@ -52,6 +54,7 @@ describe('Search JSON column - MySQL', () => {
                         },
                     ],
                 },
+                relations: [],
             });
             expect(data3).toHaveLength(1);
         });
@@ -59,6 +62,7 @@ describe('Search JSON column - MySQL', () => {
         it('should search entities that meets operation for object column', async () => {
             const { data } = await service.reservedSearch({
                 requestSearchDto: { where: [{ address: { operator: 'JSON_CONTAINS', operand: '{ "city": "Bali" }' } }] },
+                relations: [],
             });
             expect(data).toHaveLength(1);
         });
@@ -66,6 +70,7 @@ describe('Search JSON column - MySQL', () => {
         it('should return empty array when no record matches', async () => {
             const { data } = await service.reservedSearch({
                 requestSearchDto: { where: [{ friends: { operator: 'JSON_CONTAINS', operand: '{ "firstName": "Donghyuk" }' } }] },
+                relations: [],
             });
             expect(data).toHaveLength(0);
         });

--- a/spec/search-json-column/search-jsonb-postgresql.spec.ts
+++ b/spec/search-json-column/search-jsonb-postgresql.spec.ts
@@ -33,6 +33,7 @@ describe('Search JSONB column - PostgreSQL', () => {
         it('should search entities that meets operation', async () => {
             const { data } = await service.reservedSearch({
                 requestSearchDto: { where: [{ colors: { operator: '?', operand: 'Orange' } }] },
+                relations: [],
             });
             expect(data).toHaveLength(2);
         });
@@ -40,6 +41,7 @@ describe('Search JSONB column - PostgreSQL', () => {
         it('should return empty array when no record matches', async () => {
             const { data } = await service.reservedSearch({
                 requestSearchDto: { where: [{ colors: { operator: '?', operand: 'Gold' } }] },
+                relations: [],
             });
             expect(data).toHaveLength(0);
         });
@@ -49,11 +51,13 @@ describe('Search JSONB column - PostgreSQL', () => {
         it('should search entities that meets operation', async () => {
             const { data } = await service.reservedSearch({
                 requestSearchDto: { where: [{ friends: { operator: '@>', operand: '[{ "firstName": "Taylor" }]' } }] },
+                relations: [],
             });
             expect(data).toHaveLength(1);
 
             const { data: data2 } = await service.reservedSearch({
                 requestSearchDto: { where: [{ friends: { operator: '@>', operand: '[{ "gender": "Male" }]' } }] },
+                relations: [],
             });
             expect(data2).toHaveLength(2);
 
@@ -61,6 +65,7 @@ describe('Search JSONB column - PostgreSQL', () => {
                 requestSearchDto: {
                     where: [{ friends: { operator: '@>', operand: '[{ "lastName": "Bon", "email": "mbon2@pagesperso-orange.fr"}]' } }],
                 },
+                relations: [],
             });
             expect(data3).toHaveLength(1);
         });
@@ -68,6 +73,7 @@ describe('Search JSONB column - PostgreSQL', () => {
         it('should return empty array when no record matches', async () => {
             const { data } = await service.reservedSearch({
                 requestSearchDto: { where: [{ friends: { operator: '@>', operand: '[{ "firstName": "Donghyuk" }]' } }] },
+                relations: [],
             });
             expect(data).toHaveLength(0);
         });

--- a/spec/search/search-query-operator.spec.ts
+++ b/spec/search/search-query-operator.spec.ts
@@ -63,7 +63,10 @@ describe('Search Query Operator', () => {
         ];
 
         for (const requestSearchDto of requestSearchDtoList) {
-            const { data, metadata } = await service.reservedSearch({ requestSearchDto });
+            const { data, metadata } = await service.reservedSearch({
+                requestSearchDto,
+                relations: [],
+            });
             expect(data).toHaveLength(5);
             expect(Object.keys(data[0])).toEqual(expect.arrayContaining(requestSearchDto.select as unknown[]));
 
@@ -109,7 +112,7 @@ describe('Search Query Operator', () => {
             [{ where: [{ col3: { operator: 'NULL', not: true } }] }, [0, 1, 2, 3, 4]],
         ];
         for (const [requestSearchDto, expected] of fixtures) {
-            const { data, metadata } = await service.reservedSearch({ requestSearchDto });
+            const { data, metadata } = await service.reservedSearch({ requestSearchDto, relations: [] });
             const col2Values = data.map((d) => d.col2);
             expect(col2Values).toHaveLength(expected.length);
             expect(col2Values).toEqual(expect.arrayContaining(expected));
@@ -164,7 +167,7 @@ describe('Search Query Operator', () => {
             ],
         ];
         for (const [requestSearchDto, expected] of fixtures) {
-            const { data, metadata } = await service.reservedSearch({ requestSearchDto });
+            const { data, metadata } = await service.reservedSearch({ requestSearchDto, relations: [] });
             const col2Values = data.map((d) => d.col2);
             expect(col2Values).toHaveLength(expected.length);
             expect(col2Values).toEqual(expect.arrayContaining(expected));

--- a/src/lib/crud.service.spec.ts
+++ b/src/lib/crud.service.spec.ts
@@ -23,9 +23,9 @@ describe('CrudService', () => {
         });
 
         it('should return entity', async () => {
-            await expect(crudService.reservedReadOne({ params: { id: mockEntity.id } as Partial<BaseEntity> })).resolves.toEqual(
-                mockEntity,
-            );
+            await expect(
+                crudService.reservedReadOne({ params: { id: mockEntity.id } as Partial<BaseEntity>, relations: [] }),
+            ).resolves.toEqual(mockEntity);
         });
     });
 

--- a/src/lib/dto/pagination-cursor.dto.ts
+++ b/src/lib/dto/pagination-cursor.dto.ts
@@ -14,5 +14,5 @@ export class PaginationCursorDto implements PaginationRequestAbstract {
     @Expose({ name: 'query' })
     @IsString()
     @IsOptional()
-    query?: string;
+    query: string;
 }

--- a/src/lib/interceptor/create-request.interceptor.spec.ts
+++ b/src/lib/interceptor/create-request.interceptor.spec.ts
@@ -27,7 +27,7 @@ describe('CreateRequestInterceptor', () => {
 
     it('should intercepts and validate body', async () => {
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        const Interceptor = CreateRequestInterceptor({ entity: BodyDto }, { logger: new CrudLogger() });
+        const Interceptor = CreateRequestInterceptor({ entity: BodyDto }, { relations: [], logger: new CrudLogger() });
         const interceptor = new Interceptor();
         expect(await interceptor.validateBody({ col1: 1, col2: '2' })).toEqual({ col1: '1', col2: 2 });
         expect(await interceptor.validateBody({ col1: 1, col2: 2 })).toEqual({ col1: '1', col2: 2 });
@@ -39,7 +39,7 @@ describe('CreateRequestInterceptor', () => {
 
     it('should intercepts and validate body which is array', async () => {
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        const Interceptor = CreateRequestInterceptor({ entity: BodyDto }, { logger: new CrudLogger() });
+        const Interceptor = CreateRequestInterceptor({ entity: BodyDto }, { relations: [], logger: new CrudLogger() });
         const interceptor = new Interceptor();
         expect(
             await interceptor.validateBody([

--- a/src/lib/interceptor/delete-request.interceptor.spec.ts
+++ b/src/lib/interceptor/delete-request.interceptor.spec.ts
@@ -13,7 +13,7 @@ describe('DeleteRequestInterceptor', () => {
             col1: string;
         }
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        const Interceptor = DeleteRequestInterceptor({ entity: BodyDto }, { logger: new CrudLogger() });
+        const Interceptor = DeleteRequestInterceptor({ entity: BodyDto }, { relations: [], logger: new CrudLogger() });
         const interceptor = new Interceptor();
 
         const handler: CallHandler = {

--- a/src/lib/interceptor/delete-request.interceptor.ts
+++ b/src/lib/interceptor/delete-request.interceptor.ts
@@ -23,7 +23,7 @@ export function DeleteRequestInterceptor(crudOptions: CrudOptions, factoryOption
 
             const softDeleted = _.isBoolean(customDeleteRequestOptions?.softDeleted)
                 ? customDeleteRequestOptions.softDeleted
-                : deleteOptions.softDelete ?? (CRUD_POLICY[method].default?.softDeleted as boolean);
+                : deleteOptions.softDelete ?? CRUD_POLICY[method].default.softDeleted;
 
             const params = await this.checkParams(crudOptions.entity, req.params, factoryOption.columns);
             const crudDeleteOneRequest: CrudDeleteOneRequest<typeof crudOptions.entity> = {

--- a/src/lib/interceptor/read-many-request.interceptor.spec.ts
+++ b/src/lib/interceptor/read-many-request.interceptor.spec.ts
@@ -39,7 +39,7 @@ describe('ReadManyRequestInterceptor', () => {
 
         expect(interceptor.getPaginationRequest(PaginationType.CURSOR, { key: 'value', nextCursor: 'token' })).toEqual({
             nextCursor: 'token',
-            query: 'e30=',
+            query: btoa('{}'),
             type: 'cursor',
         });
     });

--- a/src/lib/interceptor/read-many-request.interceptor.spec.ts
+++ b/src/lib/interceptor/read-many-request.interceptor.spec.ts
@@ -20,6 +20,7 @@ describe('ReadManyRequestInterceptor', () => {
             { entity: {} as typeof BaseEntity },
             {
                 columns: [{ name: 'col1', type: 'string', isPrimary: false }],
+                relations: [],
                 primaryKeys: [{ name: 'col1', type: 'string' }],
                 logger: new CrudLogger(),
             },
@@ -33,11 +34,12 @@ describe('ReadManyRequestInterceptor', () => {
     });
 
     it('should be able to return pagination for GET_MORE type', () => {
-        const Interceptor = ReadManyRequestInterceptor({ entity: {} as typeof BaseEntity }, { logger: new CrudLogger() });
+        const Interceptor = ReadManyRequestInterceptor({ entity: {} as typeof BaseEntity }, { relations: [], logger: new CrudLogger() });
         const interceptor = new Interceptor();
 
         expect(interceptor.getPaginationRequest(PaginationType.CURSOR, { key: 'value', nextCursor: 'token' })).toEqual({
             nextCursor: 'token',
+            query: 'e30=',
             type: 'cursor',
         });
     });
@@ -61,10 +63,10 @@ describe('ReadManyRequestInterceptor', () => {
             col3: number;
         }
 
-        const Interceptor = ReadManyRequestInterceptor({ entity: QueryDto }, { logger: new CrudLogger() });
+        const Interceptor = ReadManyRequestInterceptor({ entity: QueryDto }, { relations: [], logger: new CrudLogger() });
         const interceptor = new Interceptor();
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        expect(await interceptor.validateQuery(undefined as any)).toBeUndefined();
+        expect(await interceptor.validateQuery(undefined as any)).toEqual({});
         expect(await interceptor.validateQuery({ col1: 1, col2: '2' })).toEqual({
             col1: '1',
             col2: 2,
@@ -80,16 +82,16 @@ describe('ReadManyRequestInterceptor', () => {
     });
 
     it('should be get relation values per each condition', () => {
-        const Interceptor = ReadManyRequestInterceptor({ entity: {} as typeof BaseEntity }, { logger: new CrudLogger() });
+        const Interceptor = ReadManyRequestInterceptor({ entity: {} as typeof BaseEntity }, { relations: [], logger: new CrudLogger() });
         const interceptor = new Interceptor();
 
         expect(interceptor.getRelations({ relations: [] })).toEqual([]);
         expect(interceptor.getRelations({ relations: ['table'] })).toEqual(['table']);
-        expect(interceptor.getRelations({})).toBeUndefined();
+        expect(interceptor.getRelations({})).toEqual([]);
 
         const InterceptorWithOptions = ReadManyRequestInterceptor(
             { entity: {} as typeof BaseEntity, routes: { readMany: { relations: ['option'] } } },
-            { logger: new CrudLogger() },
+            { relations: [], logger: new CrudLogger() },
         );
         const interceptorWithOptions = new InterceptorWithOptions();
         expect(interceptorWithOptions.getRelations({ relations: [] })).toEqual([]);
@@ -98,7 +100,7 @@ describe('ReadManyRequestInterceptor', () => {
 
         const InterceptorWithFalseOptions = ReadManyRequestInterceptor(
             { entity: {} as typeof BaseEntity, routes: { readMany: { relations: false } } },
-            { logger: new CrudLogger() },
+            { relations: [], logger: new CrudLogger() },
         );
         const interceptorWithFalseOptions = new InterceptorWithFalseOptions();
         expect(interceptorWithFalseOptions.getRelations({ relations: [] })).toEqual([]);
@@ -107,7 +109,7 @@ describe('ReadManyRequestInterceptor', () => {
     });
 
     it('should be validate pagination query', () => {
-        const Interceptor = ReadManyRequestInterceptor({ entity: {} as typeof BaseEntity }, { logger: new CrudLogger() });
+        const Interceptor = ReadManyRequestInterceptor({ entity: {} as typeof BaseEntity }, { relations: [], logger: new CrudLogger() });
         const interceptor = new Interceptor();
 
         interceptor.getPaginationRequest(PaginationType.CURSOR, undefined as any);

--- a/src/lib/interceptor/read-many-request.interceptor.ts
+++ b/src/lib/interceptor/read-many-request.interceptor.ts
@@ -76,7 +76,7 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
             }
 
             if (transformed.type === PaginationType.CURSOR && transformed.nextCursor && !transformed.query) {
-                transformed.query = 'e30=';
+                transformed.query = btoa('{}');
             }
 
             return transformed;

--- a/src/lib/interceptor/read-many-request.interceptor.ts
+++ b/src/lib/interceptor/read-many-request.interceptor.ts
@@ -11,7 +11,8 @@ import { CRUD_ROUTE_ARGS, CUSTOM_REQUEST_OPTIONS } from '../constants';
 import { CRUD_POLICY } from '../crud.policy';
 import { PaginationCursorDto } from '../dto/pagination-cursor.dto';
 import { PaginationOffsetDto } from '../dto/pagination-offset.dto';
-import { CrudOptions, CrudReadManyRequest, FactoryOption, Method, Sort, GROUP, PaginationType, PaginationRequest } from '../interface';
+import { CrudOptions, FactoryOption, Method, Sort, GROUP, PaginationType, PaginationRequest } from '../interface';
+import { CrudReadManyRequest } from '../request';
 
 const method = Method.READ_MANY;
 export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOption: FactoryOption) {
@@ -38,26 +39,25 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
                     (pagination.type === PaginationType.CURSOR && !_.isNil(pagination['nextCursor'])) ||
                     (pagination.type === PaginationType.OFFSET && (!_.isNil(pagination['offset']) || !_.isNil(pagination['limit'])))
                 ) {
-                    return;
+                    return {};
                 }
                 return this.validateQuery(req.query);
             })();
+            const crudReadManyRequest: CrudReadManyRequest<typeof crudOptions.entity> = new CrudReadManyRequest<typeof crudOptions.entity>()
+                .setPrimaryKey(factoryOption.primaryKeys ?? [])
+                .setPagination(pagination)
+                .setWithDeleted(
+                    _.isBoolean(customReadManyRequestOptions?.softDeleted)
+                        ? customReadManyRequestOptions.softDeleted
+                        : crudOptions.routes?.[method]?.softDelete ?? (CRUD_POLICY[method].default.softDeleted as boolean),
+                )
+                .setWhere(query)
+                .setTake(readManyOptions.numberOfTake ?? CRUD_POLICY[method].default.numberOfTake)
+                .setSort(readManyOptions.sort ? Sort[readManyOptions.sort] : (CRUD_POLICY[method].default.sort as Sort))
+                .setRelations(this.getRelations(customReadManyRequestOptions))
+                .generate();
 
-            const softDeleted = _.isBoolean(customReadManyRequestOptions?.softDeleted)
-                ? customReadManyRequestOptions.softDeleted
-                : crudOptions.routes?.[method]?.softDelete ?? (CRUD_POLICY[method].default?.softDelete as boolean);
-
-            const crudReadManyRequest: CrudReadManyRequest<typeof crudOptions.entity> = {
-                sort: readManyOptions.sort ? Sort[readManyOptions.sort] : (CRUD_POLICY[method].default?.sort as Sort),
-                pagination,
-                numberOfTake: readManyOptions.numberOfTake ?? (CRUD_POLICY[method].default?.numberOfTake as number),
-                query,
-                primaryKeys: factoryOption.primaryKeys ?? [],
-                relations: this.getRelations(customReadManyRequestOptions),
-                softDeleted,
-            };
-
-            this.crudLogger.logRequest(req, crudReadManyRequest);
+            this.crudLogger.logRequest(req, crudReadManyRequest.toString());
             req[CRUD_ROUTE_ARGS] = crudReadManyRequest;
 
             return next.handle();
@@ -74,12 +74,17 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
             if (error) {
                 throw new UnprocessableEntityException(error);
             }
+
+            if (transformed.type === PaginationType.CURSOR && transformed.nextCursor && !transformed.query) {
+                transformed.query = 'e30=';
+            }
+
             return transformed;
         }
 
         async validateQuery(query: Record<string, unknown>) {
             if (_.isNil(query)) {
-                return;
+                return {};
             }
 
             const transformed = plainToInstance(crudOptions.entity, query, { groups: [GROUP.READ_MANY] });
@@ -98,7 +103,7 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
             return transformed;
         }
 
-        getRelations(customReadManyRequestOptions: CustomReadManyRequestOptions): string[] | undefined {
+        getRelations(customReadManyRequestOptions: CustomReadManyRequestOptions): string[] {
             if (Array.isArray(customReadManyRequestOptions?.relations)) {
                 return customReadManyRequestOptions.relations;
             }
@@ -108,6 +113,7 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
             if (crudOptions.routes?.[method] && Array.isArray(crudOptions.routes?.[method]?.relations)) {
                 return crudOptions.routes[method].relations;
             }
+            return factoryOption.relations;
         }
     }
 

--- a/src/lib/interceptor/read-one-request.interceptor.spec.ts
+++ b/src/lib/interceptor/read-one-request.interceptor.spec.ts
@@ -17,7 +17,7 @@ describe('ReadOneRequestInterceptor', () => {
     it('should intercept and pass CrudReadOneRequest', async () => {
         const Interceptor = ReadOneRequestInterceptor(
             { entity: {} as typeof BaseEntity },
-            { columns: [{ name: 'col1', type: 'string', isPrimary: false }], logger: new CrudLogger() },
+            { columns: [{ name: 'col1', type: 'string', isPrimary: false }], relations: [], logger: new CrudLogger() },
         );
         const interceptor = new Interceptor();
 
@@ -28,7 +28,7 @@ describe('ReadOneRequestInterceptor', () => {
     });
 
     it('should get fields from interceptor fields and request fields', () => {
-        const Interceptor = ReadOneRequestInterceptor({ entity: {} as typeof BaseEntity }, { logger: new CrudLogger() });
+        const Interceptor = ReadOneRequestInterceptor({ entity: {} as typeof BaseEntity }, { relations: [], logger: new CrudLogger() });
         const interceptor = new Interceptor();
 
         expect(interceptor.getFields(undefined, undefined)).toEqual([]);
@@ -48,6 +48,7 @@ describe('ReadOneRequestInterceptor', () => {
                     { name: 'col2', type: 'string', isPrimary: false },
                     { name: 'col3', type: 'string', isPrimary: false },
                 ],
+                relations: [],
                 logger: new CrudLogger(),
             },
         );
@@ -70,7 +71,10 @@ describe('ReadOneRequestInterceptor', () => {
     });
 
     it('should throw when fields are invalid', () => {
-        const Interceptor = ReadOneRequestInterceptor({ entity: {} as typeof BaseEntity }, { columns: [], logger: new CrudLogger() });
+        const Interceptor = ReadOneRequestInterceptor(
+            { entity: {} as typeof BaseEntity },
+            { columns: [], relations: [], logger: new CrudLogger() },
+        );
         const interceptor = new Interceptor();
 
         const invalidFieldsList = [1, [1, 2], [['col1', 'col2']], {}, [undefined], [null]];
@@ -82,7 +86,7 @@ describe('ReadOneRequestInterceptor', () => {
     });
 
     it('should get relations from custom request options and crudOption', async () => {
-        const Interceptor = ReadOneRequestInterceptor({ entity: {} as typeof BaseEntity }, { logger: new CrudLogger() });
+        const Interceptor = ReadOneRequestInterceptor({ entity: {} as typeof BaseEntity }, { relations: [], logger: new CrudLogger() });
         const interceptor = new Interceptor();
 
         const mockRequest: any = jest.fn();
@@ -93,7 +97,7 @@ describe('ReadOneRequestInterceptor', () => {
 
         const InterceptorNoRelations = ReadOneRequestInterceptor(
             { entity: {} as typeof BaseEntity, routes: { [Method.READ_ONE]: { relations: false } } },
-            { logger: new CrudLogger() },
+            { relations: [], logger: new CrudLogger() },
         );
         const interceptorNoRelations = new InterceptorNoRelations();
 
@@ -105,7 +109,7 @@ describe('ReadOneRequestInterceptor', () => {
 
         const InterceptorWithRelations = ReadOneRequestInterceptor(
             { entity: {} as typeof BaseEntity, routes: { [Method.READ_ONE]: { relations: ['bar'] } } },
-            { logger: new CrudLogger() },
+            { relations: [], logger: new CrudLogger() },
         );
         const interceptorWithRelations = new InterceptorWithRelations();
 

--- a/src/lib/interceptor/read-one-request.interceptor.ts
+++ b/src/lib/interceptor/read-one-request.interceptor.ts
@@ -29,7 +29,7 @@ export function ReadOneRequestInterceptor(crudOptions: CrudOptions, factoryOptio
 
             const softDeleted = _.isBoolean(customReadOneRequestOptions?.softDeleted)
                 ? customReadOneRequestOptions.softDeleted
-                : crudOptions.routes?.[method]?.softDelete ?? (CRUD_POLICY[method].default?.softDelete as boolean);
+                : crudOptions.routes?.[method]?.softDelete ?? (CRUD_POLICY[method].default.softDeleted as boolean);
 
             const params = await this.checkParams(crudOptions.entity, req.params, factoryOption.columns);
 
@@ -75,7 +75,7 @@ export function ReadOneRequestInterceptor(crudOptions: CrudOptions, factoryOptio
             return requestFields.fields;
         }
 
-        getRelations(customReadOneRequestOptions: CustomReadOneRequestOptions): string[] | undefined {
+        getRelations(customReadOneRequestOptions: CustomReadOneRequestOptions): string[] {
             if (Array.isArray(customReadOneRequestOptions?.relations)) {
                 return customReadOneRequestOptions.relations;
             }
@@ -85,6 +85,7 @@ export function ReadOneRequestInterceptor(crudOptions: CrudOptions, factoryOptio
             if (crudOptions.routes?.[method] && Array.isArray(crudOptions.routes?.[method]?.relations)) {
                 return crudOptions.routes[method].relations;
             }
+            return factoryOption.relations;
         }
     }
     return mixin(MixinInterceptor);

--- a/src/lib/interceptor/recover-request.interceptor.spec.ts
+++ b/src/lib/interceptor/recover-request.interceptor.spec.ts
@@ -13,7 +13,7 @@ describe('RecoverRequestInterceptor', () => {
             col1: string;
         }
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        const Interceptor = RecoverRequestInterceptor({ entity: BodyDto }, { logger: new CrudLogger() });
+        const Interceptor = RecoverRequestInterceptor({ entity: BodyDto }, { relations: [], logger: new CrudLogger() });
         const interceptor = new Interceptor();
         const handler: CallHandler = {
             handle: () => of('test'),

--- a/src/lib/interceptor/search-request.interceptor.spec.ts
+++ b/src/lib/interceptor/search-request.interceptor.spec.ts
@@ -32,6 +32,7 @@ describe('SearchRequestInterceptor', () => {
                     { name: 'col2', type: 'number', isPrimary: false },
                     { name: 'col3', type: 'number', isPrimary: false },
                 ],
+                relations: [],
                 logger: new CrudLogger(),
             },
         );

--- a/src/lib/interceptor/search-request.interceptor.ts
+++ b/src/lib/interceptor/search-request.interceptor.ts
@@ -40,7 +40,7 @@ export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption
             const requestSearchDto = await this.validateBody(req.body);
             const crudSearchRequest: CrudSearchRequest<typeof crudOptions.entity> = {
                 requestSearchDto,
-                relations: customSearchRequestOptions?.relations,
+                relations: customSearchRequestOptions?.relations ?? factoryOption.relations,
             };
 
             this.crudLogger.logRequest(req, crudSearchRequest);
@@ -77,13 +77,13 @@ export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption
             if ('withDeleted' in requestSearchDto) {
                 this.validateWithDeleted(requestSearchDto.withDeleted);
             } else {
-                requestSearchDto.withDeleted = searchOptions.softDelete ?? (CRUD_POLICY[method].default?.softDeleted as boolean);
+                requestSearchDto.withDeleted = searchOptions.softDelete ?? (CRUD_POLICY[method].default.softDeleted as boolean);
             }
 
             requestSearchDto.take =
                 'take' in requestSearchDto
                     ? this.validateTake(requestSearchDto.take, searchOptions.limitOfTake)
-                    : searchOptions.numberOfTake ?? (CRUD_POLICY[method].default?.numberOfTake as number);
+                    : searchOptions.numberOfTake ?? (CRUD_POLICY[method].default.numberOfTake as number);
 
             return requestSearchDto;
         }
@@ -103,7 +103,7 @@ export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption
                 (queryFilter, [key, operand]) => ({
                     ...queryFilter,
                     [key]: {
-                        operator: _.get(preCondition.order, key, CRUD_POLICY[method].default?.sort) === Sort.DESC ? '<' : '>',
+                        operator: _.get(preCondition.order, key, CRUD_POLICY[method].default.sort) === Sort.DESC ? '<' : '>',
                         operand,
                     },
                 }),

--- a/src/lib/interceptor/update-request.interceptor.spec.ts
+++ b/src/lib/interceptor/update-request.interceptor.spec.ts
@@ -30,7 +30,7 @@ describe('UpdateRequestInterceptor', () => {
 
         const Interceptor = UpdateRequestInterceptor(
             { entity: BodyDto },
-            { primaryKeys: [{ name: 'col1', type: 'string' }], logger: new CrudLogger() },
+            { primaryKeys: [{ name: 'col1', type: 'string' }], relations: [], logger: new CrudLogger() },
         );
         const interceptor = new Interceptor();
 
@@ -57,7 +57,7 @@ describe('UpdateRequestInterceptor', () => {
             @Type(() => Number)
             col3: number;
         }
-        const Interceptor = UpdateRequestInterceptor({ entity: BodyDto }, { primaryKeys: [], logger: new CrudLogger() });
+        const Interceptor = UpdateRequestInterceptor({ entity: BodyDto }, { primaryKeys: [], relations: [], logger: new CrudLogger() });
         const interceptor = new Interceptor();
         expect(await interceptor.validateBody({ col1: 1, col2: '2' })).toEqual({
             col1: '1',
@@ -75,7 +75,10 @@ describe('UpdateRequestInterceptor', () => {
     });
 
     it('should throw when body is null or undefined', async () => {
-        const Interceptor = UpdateRequestInterceptor({ entity: {} as typeof BaseEntity }, { primaryKeys: [], logger: new CrudLogger() });
+        const Interceptor = UpdateRequestInterceptor(
+            { entity: {} as typeof BaseEntity },
+            { primaryKeys: [], relations: [], logger: new CrudLogger() },
+        );
         const interceptor = new Interceptor();
 
         await expect(interceptor.validateBody(null)).rejects.toThrow(UnprocessableEntityException);
@@ -83,7 +86,10 @@ describe('UpdateRequestInterceptor', () => {
     });
 
     it('should throw when body is not object', async () => {
-        const Interceptor = UpdateRequestInterceptor({ entity: {} as typeof BaseEntity }, { primaryKeys: [], logger: new CrudLogger() });
+        const Interceptor = UpdateRequestInterceptor(
+            { entity: {} as typeof BaseEntity },
+            { primaryKeys: [], relations: [], logger: new CrudLogger() },
+        );
         const interceptor = new Interceptor();
 
         await expect(interceptor.validateBody(1)).rejects.toThrow(UnprocessableEntityException);

--- a/src/lib/interceptor/upsert-request.interceptor.spec.ts
+++ b/src/lib/interceptor/upsert-request.interceptor.spec.ts
@@ -30,7 +30,7 @@ describe('UpsertRequestInterceptor', () => {
 
         const Interceptor = UpsertRequestInterceptor(
             { entity: BodyDto },
-            { primaryKeys: [{ name: 'col1', type: 'string' }], logger: new CrudLogger() },
+            { primaryKeys: [{ name: 'col1', type: 'string' }], relations: [], logger: new CrudLogger() },
         );
         const interceptor = new Interceptor();
 
@@ -58,7 +58,7 @@ describe('UpsertRequestInterceptor', () => {
             @Type(() => Number)
             col3: number;
         }
-        const Interceptor = UpsertRequestInterceptor({ entity: BodyDto }, { primaryKeys: [], logger: new CrudLogger() });
+        const Interceptor = UpsertRequestInterceptor({ entity: BodyDto }, { primaryKeys: [], relations: [], logger: new CrudLogger() });
         const interceptor = new Interceptor();
         expect(await interceptor.validateBody({ col1: 1, col2: '2' })).toEqual({
             col1: '1',
@@ -76,7 +76,10 @@ describe('UpsertRequestInterceptor', () => {
     });
 
     it('should throw when body is null or undefined', async () => {
-        const Interceptor = UpsertRequestInterceptor({ entity: {} as typeof BaseEntity }, { primaryKeys: [], logger: new CrudLogger() });
+        const Interceptor = UpsertRequestInterceptor(
+            { entity: {} as typeof BaseEntity },
+            { primaryKeys: [], relations: [], logger: new CrudLogger() },
+        );
         const interceptor = new Interceptor();
 
         await expect(interceptor.validateBody(null)).rejects.toThrow(UnprocessableEntityException);
@@ -84,7 +87,10 @@ describe('UpsertRequestInterceptor', () => {
     });
 
     it('should throw when body is not object', async () => {
-        const Interceptor = UpsertRequestInterceptor({ entity: {} as typeof BaseEntity }, { primaryKeys: [], logger: new CrudLogger() });
+        const Interceptor = UpsertRequestInterceptor(
+            { entity: {} as typeof BaseEntity },
+            { primaryKeys: [], relations: [], logger: new CrudLogger() },
+        );
         const interceptor = new Interceptor();
 
         await expect(interceptor.validateBody(1)).rejects.toThrow(UnprocessableEntityException);

--- a/src/lib/interface/factory-option.interface.ts
+++ b/src/lib/interface/factory-option.interface.ts
@@ -11,5 +11,6 @@ export interface Column {
 export interface FactoryOption {
     logger: CrudLogger;
     columns?: Column[];
+    relations: string[];
     primaryKeys?: Array<Omit<Column, 'isPrimary'>>;
 }

--- a/src/lib/interface/request.interface.ts
+++ b/src/lib/interface/request.interface.ts
@@ -1,6 +1,6 @@
 import { DeepPartial } from 'typeorm';
 
-import { Author, PaginationRequest, PrimaryKey, Sort } from '.';
+import { Author } from '.';
 import { RequestSearchDto } from '../dto/request-search.dto';
 
 export type CrudRequestId<T> = keyof T | Array<keyof T>;
@@ -11,15 +11,7 @@ export interface CrudRequestBase {
 
 export interface CrudReadRequestBase extends CrudRequestBase {
     softDeleted?: boolean;
-    relations?: string[];
-}
-
-export interface CrudReadManyRequest<T> extends CrudReadRequestBase {
-    query?: Partial<Record<keyof T, unknown>>;
-    sort: Sort;
-    primaryKeys: PrimaryKey[];
-    pagination: PaginationRequest;
-    numberOfTake: number;
+    relations: string[];
 }
 
 export interface CrudReadOneRequest<T> extends CrudReadRequestBase {
@@ -29,7 +21,7 @@ export interface CrudReadOneRequest<T> extends CrudReadRequestBase {
 
 export interface CrudSearchRequest<T> extends CrudRequestBase {
     requestSearchDto: RequestSearchDto<T>;
-    relations?: string[];
+    relations: string[];
 }
 
 export interface CrudCreateOneRequest<T> extends CrudRequestBase {

--- a/src/lib/provider/pagination.helper.ts
+++ b/src/lib/provider/pagination.helper.ts
@@ -1,7 +1,9 @@
+import { FindOptionsWhere } from 'typeorm';
+
 const encoding = 'base64';
 
 export class PaginationHelper {
-    static serialize<T>(entity: Partial<T>): string {
+    static serialize<T>(entity: FindOptionsWhere<T>): string {
         return Buffer.from(JSON.stringify(entity)).toString(encoding);
     }
 

--- a/src/lib/request/index.ts
+++ b/src/lib/request/index.ts
@@ -1,0 +1,1 @@
+export * from './read-many.request';

--- a/src/lib/request/read-many.request.spec.ts
+++ b/src/lib/request/read-many.request.spec.ts
@@ -1,0 +1,8 @@
+import { CrudReadManyRequest } from '.';
+
+describe('CrudReadManyRequest', () => {
+    it('should be defined', () => {
+        const crudReadManyRequest = new CrudReadManyRequest();
+        expect(crudReadManyRequest).toBeDefined();
+    });
+});

--- a/src/lib/request/read-many.request.ts
+++ b/src/lib/request/read-many.request.ts
@@ -1,0 +1,127 @@
+import _ from 'lodash';
+import { FindManyOptions, FindOptionsWhere, LessThan, MoreThan } from 'typeorm';
+
+import { CRUD_POLICY } from '../crud.policy';
+import { Method, PaginationRequest, PaginationResponse, PaginationType, PrimaryKey, Sort } from '../interface';
+import { PaginationHelper } from '../provider';
+
+export class CrudReadManyRequest<T> {
+    private _primaryKeys: PrimaryKey[] = [];
+    private _findOptions: FindManyOptions<T> & { where: FindOptionsWhere<T>; take: number } = {
+        where: {},
+        take: CRUD_POLICY[Method.READ_MANY].default.numberOfTake,
+    };
+    private _sort: Sort;
+    private _pagination: PaginationRequest;
+
+    get primaryKeys() {
+        return this._primaryKeys;
+    }
+    get findOptions() {
+        return this._findOptions;
+    }
+    get pagination() {
+        return this._pagination;
+    }
+
+    setPagination(pagination: PaginationRequest): this {
+        this._pagination = pagination;
+        return this;
+    }
+
+    setPrimaryKey(primaryKeys: PrimaryKey[]): this {
+        this._primaryKeys = primaryKeys;
+        return this;
+    }
+
+    setWithDeleted(withDeleted: boolean): this {
+        this._findOptions.withDeleted = withDeleted;
+        return this;
+    }
+
+    setWhere(where: FindOptionsWhere<T> & Partial<T>): this {
+        this._findOptions.where = where;
+        return this;
+    }
+
+    setTake(take: number): this {
+        this._findOptions.take = take;
+        return this;
+    }
+
+    setSort(sort: Sort): this {
+        this._sort = sort;
+        this._findOptions.order = this._primaryKeys.reduce((order, primaryKey) => ({ ...order, [primaryKey.name]: sort }), {});
+        return this;
+    }
+
+    setRelations(relations: string[] | undefined): this {
+        this._findOptions.relations = relations;
+        return this;
+    }
+
+    generate(): this {
+        if (this.pagination.type === PaginationType.OFFSET) {
+            if (!!this.pagination.limit) {
+                this._findOptions.take = this.pagination.limit;
+            }
+            if (Number.isFinite(this.pagination.offset)) {
+                this._findOptions.where = PaginationHelper.deserialize(this.pagination.query);
+                this._findOptions.skip = this.pagination.offset;
+            }
+        }
+
+        if (this.pagination.type === PaginationType.CURSOR && this.pagination.nextCursor) {
+            this._findOptions.where = this.paginateCursorWhereByNextCursor();
+        }
+
+        return this;
+    }
+
+    toString(): string {
+        return JSON.stringify(this);
+    }
+
+    toResponse(data: T[], total: number): PaginationResponse<T> {
+        if (this.pagination.type === PaginationType.OFFSET) {
+            return {
+                data,
+                metadata: {
+                    page: this.pagination.offset ? Math.floor(this.pagination.offset / this.findOptions.take) + 1 : 1,
+                    pages: total ? Math.ceil(total / this.findOptions.take) : 1,
+                    total,
+                    offset: (this.pagination.offset ?? 0) + data.length,
+                    query: this.pagination.query ?? PaginationHelper.serialize(this.findOptions.where),
+                },
+            };
+        }
+        return {
+            data,
+            metadata: {
+                nextCursor: PaginationHelper.serialize(
+                    _.pick(
+                        data.at(-1),
+                        this.primaryKeys.map(({ name }) => name),
+                    ) as FindOptionsWhere<T>,
+                ),
+                limit: this.findOptions.take,
+                total,
+                query: this.pagination.query ?? PaginationHelper.serialize(this.findOptions.where),
+            },
+        };
+    }
+
+    private paginateCursorWhereByNextCursor(): FindOptionsWhere<T> {
+        if (this.pagination.type !== PaginationType.CURSOR) {
+            return {};
+        }
+        const query: Record<string, unknown> = PaginationHelper.deserialize(this.pagination.query);
+        const lastObject: Record<string, unknown> = PaginationHelper.deserialize(this.pagination.nextCursor);
+
+        const operator = this._sort === Sort.DESC ? LessThan : MoreThan;
+        for (const [key, value] of Object.entries(lastObject)) {
+            query[key] = operator(value);
+        }
+        return query as FindOptionsWhere<T>;
+    }
+}

--- a/src/lib/request/read-many.request.ts
+++ b/src/lib/request/read-many.request.ts
@@ -62,7 +62,7 @@ export class CrudReadManyRequest<T> {
 
     generate(): this {
         if (this.pagination.type === PaginationType.OFFSET) {
-            if (!!this.pagination.limit) {
+            if (this.pagination.limit != null) {
                 this._findOptions.take = this.pagination.limit;
             }
             if (Number.isFinite(this.pagination.offset)) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [x] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

As the `number of ways to fetch increases`, the core goal of `read many entities` does not change.

The ReadMany features has `ReadMany-Offset Pagination`, `ReadMany-Cursor Pagination` and `Search-Cursor Pagination`. 

Since each function is implemented separately, it have to add a new one every time.

To `clear these issues` and `protect the core logic`, I propose the following.
- Separate the core functionality from the Request Interface and Response Interface in ReadMany.


## What is the new behavior?

1. Clarifies the `typing of default` for CRUD_POLICY.
 - `CRUD_POLICY.defalut` is no longer optional, and by Method has a definite default type. 
2. `relations`  is added to the CrudRouteFactory.
 - The relations is no longer managed on the service.
3. Service removes the dependency on pagination.
  - Pagination is just an interface option for the ReadMany feature and has no service-wide impact.
4. Added the `CrudReadManyRequest class` to manage the interface for the ReadMany feature.
  - Simplifies the implementation of ReadMany `core logic` in a Service
  - By separating the `interface`, it can use the ReadMany core function on different interfaces.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Continued from https://github.com/woowabros/nestjs-library-crud/pull/243

I am preparing to use `CrudReadManyRequest for the search` feature, which will provide the same functionality and interface as ReadMany (Cursor & offset pagination).
