### PR TITLE
feat: support offset Pagination on search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,6 @@ jobs:
 
             - name: Coveralls
               uses: coverallsapp/github-action@v2
-              
 #  https://github.com/actions/typescript-action/blob/main/.github/workflows/codeql-analysis.yml
 
 #  https://github.com/actions/typescript-action/blob/main/.github/workflows/test.yml

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,61 +1,61 @@
 name: 'CodeQL'
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [main]
-  schedule:
-    - cron: "0 17 * * 4"
+    push:
+        branches: [main]
+    pull_request:
+        # The branches below must be a subset of the branches above
+        branches: [main]
+    schedule:
+        - cron: '0 17 * * 4'
 
 permissions:
-  contents: read
+    contents: read
 
 jobs:
-  analyse:
-    permissions:
-      security-events: write
-    name: Analyse
-    runs-on: ubuntu-latest
+    analyse:
+        permissions:
+            security-events: write
+        name: Analyse
+        runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          # We must fetch at least the immediate parents so that if this is
-          # a pull request then we can checkout the head.
-          fetch-depth: 2
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
+              with:
+                  # We must fetch at least the immediate parents so that if this is
+                  # a pull request then we can checkout the head.
+                  fetch-depth: 2
 
-      # If this run was triggered by a pull request event, then checkout
-      # the head of the pull request instead of the merge commit.
-      - run: git checkout HEAD^2
-        if: ${{ github.event_name == 'pull_request' }}
+            # If this run was triggered by a pull request event, then checkout
+            # the head of the pull request instead of the merge commit.
+            - run: git checkout HEAD^2
+              if: ${{ github.event_name == 'pull_request' }}
 
-      # Initializes the CodeQL tools for scanning.
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
-        with:
-          queries: +security-extended
-        # Override language selection by uncommenting this and choosing your languages
-        # with:
-        #   languages: go, javascript, csharp, python, cpp, java
+            # Initializes the CodeQL tools for scanning.
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v2
+              with:
+                  queries: +security-extended
+              # Override language selection by uncommenting this and choosing your languages
+              # with:
+              #   languages: go, javascript, csharp, python, cpp, java
 
-      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-      # If this step fails, then you should remove it and run the build manually (see below)
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+            # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+            # If this step fails, then you should remove it and run the build manually (see below)
+            - name: Autobuild
+              uses: github/codeql-action/autobuild@v2
 
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 https://git.io/JvXDl
+            # ℹ️ Command-line programs to run using the OS shell.
+            # 📚 https://git.io/JvXDl
 
-      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-      #    and modify them (or add more) to build your code if your project
-      #    uses a compiled language
+            # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+            #    and modify them (or add more) to build your code if your project
+            #    uses a compiled language
 
-      #- run: |
-      #   make bootstrap
-      #   make release
+            #- run: |
+            #   make bootstrap
+            #   make release
 
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+            - name: Perform CodeQL Analysis
+              uses: github/codeql-action/analyze@v2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-    "cSpell.words": ["Denormalized", "ILIKE", "nestjs", "Pgsql", "typeorm"],
+    "cSpell.words": ["Denormalized", "ILIKE", "metatype", "nestjs", "Pgsql", "typeorm"],
     "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -12,8 +12,6 @@ services:
             - --collation-server=utf8mb4_unicode_ci
         ports:
             - '3306:3306'
-        volumes:
-            - 'mysql_data:/var/lib/mysql'
 
     postgresql:
         image: postgres:latest
@@ -24,10 +22,3 @@ services:
             POSTGRES_PASSWORD: $POSTGRESQL_DATABASE_PASSWORD
         ports:
             - '5432:5432'
-        volumes:
-            - postgresql_data:/var/lib/postgresql/data
-volumes:
-    mysql_data:
-        driver: local
-    postgresql_data:
-        driver: local

--- a/spec/auth-guard/auth-guard.spec.ts
+++ b/spec/auth-guard/auth-guard.spec.ts
@@ -9,7 +9,7 @@ import { TestHelper } from '../test.helper';
 describe('AuthGuard', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [AuthGuardModule, TestHelper.getTypeOrmMysqlModule([BaseEntity])],
         }).compile();
@@ -19,7 +19,7 @@ describe('AuthGuard', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/author/author-object.spec.ts
+++ b/spec/author/author-object.spec.ts
@@ -8,7 +8,7 @@ import { TestHelper } from '../test.helper';
 describe('Author - object', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [TestModule, TestHelper.getTypeOrmPgsqlModule([TestEntity])],
         }).compile();
@@ -16,7 +16,7 @@ describe('Author - object', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/author/author-value.spec.ts
+++ b/spec/author/author-value.spec.ts
@@ -8,7 +8,7 @@ import { TestHelper } from '../test.helper';
 describe('Author', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [TestModule, TestHelper.getTypeOrmMysqlModule([TestEntity])],
         }).compile();
@@ -16,7 +16,7 @@ describe('Author', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/author/author.interceptor.ts
+++ b/spec/author/author.interceptor.ts
@@ -1,6 +1,5 @@
 import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
 import { Request } from 'express';
-import _ from 'lodash';
 
 @Injectable()
 export class AuthorInterceptor implements NestInterceptor {

--- a/spec/author/author.spec.ts
+++ b/spec/author/author.spec.ts
@@ -8,7 +8,7 @@ import { TestHelper } from '../test.helper';
 describe('Author', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [TestModule, TestHelper.getTypeOrmMysqlModule([TestEntity])],
         }).compile();
@@ -16,7 +16,7 @@ describe('Author', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/base/base.controller.create.spec.ts
+++ b/spec/base/base.controller.create.spec.ts
@@ -4,26 +4,25 @@ import request from 'supertest';
 
 import { BaseEntity } from './base.entity';
 import { BaseModule } from './base.module';
-import { BaseService } from './base.service';
 import { TestHelper } from '../test.helper';
 
 describe('BaseController', () => {
     let app: INestApplication;
-    let service: BaseService;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [BaseModule, TestHelper.getTypeOrmMysqlModule([BaseEntity])],
         }).compile();
         app = moduleFixture.createNestApplication();
 
-        service = moduleFixture.get<BaseService>(BaseService);
-        await Promise.all(['name1', 'name2'].map((name: string) => service.repository.save(service.repository.create({ name }))));
-
         await app.init();
     });
 
-    afterEach(async () => {
+    beforeEach(async () => {
+        await BaseEntity.delete({});
+    });
+
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/base/base.controller.delete.spec.ts
+++ b/spec/base/base.controller.delete.spec.ts
@@ -9,7 +9,7 @@ import { TestHelper } from '../test.helper';
 describe('BaseController', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [BaseModule, TestHelper.getTypeOrmMysqlModule([BaseEntity])],
         }).compile();
@@ -18,7 +18,11 @@ describe('BaseController', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    beforeEach(async () => {
+        await BaseEntity.delete({});
+    });
+
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/base/base.controller.read-many.spec.ts
+++ b/spec/base/base.controller.read-many.spec.ts
@@ -8,7 +8,7 @@ import { TestHelper } from '../test.helper';
 describe('BaseController', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [BaseModule, TestHelper.getTypeOrmMysqlModule([BaseEntity])],
         }).compile();
@@ -17,7 +17,7 @@ describe('BaseController', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/base/base.controller.read-one.spec.ts
+++ b/spec/base/base.controller.read-one.spec.ts
@@ -11,7 +11,7 @@ describe('BaseController', () => {
     let app: INestApplication;
     let service: BaseService;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [BaseModule, TestHelper.getTypeOrmMysqlModule([BaseEntity])],
         }).compile();
@@ -23,7 +23,7 @@ describe('BaseController', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });
@@ -36,14 +36,14 @@ describe('BaseController', () => {
         });
 
         it('should be returned only one entity', async () => {
-            const response = await request(app.getHttpServer())
+            const { body } = await request(app.getHttpServer())
                 .get(`/base/${id}`)
-                .query({ fields: ['id', 'name', 'createdAt'] });
+                .query({ fields: ['id', 'name', 'createdAt'] })
+                .expect(HttpStatus.OK);
 
-            expect(response.statusCode).toEqual(HttpStatus.OK);
-            expect(response.body.id).toEqual(id);
-            expect(response.body.name).toEqual(expect.any(String));
-            expect(response.body.lastModifiedAt).toBeUndefined();
+            expect(body.id).toEqual(id);
+            expect(body.name).toEqual(expect.any(String));
+            expect(body.lastModifiedAt).toBeUndefined();
         });
 
         it('should be fields feature with multiple options', async () => {

--- a/spec/base/base.controller.search.spec.ts
+++ b/spec/base/base.controller.search.spec.ts
@@ -8,7 +8,7 @@ import { TestHelper } from '../test.helper';
 describe('BaseController', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [BaseModule, TestHelper.getTypeOrmMysqlModule([BaseEntity])],
         }).compile();
@@ -17,7 +17,7 @@ describe('BaseController', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/base/base.controller.spec.ts
+++ b/spec/base/base.controller.spec.ts
@@ -12,7 +12,7 @@ describe('BaseController', () => {
     let controller: BaseController;
     let service: BaseService;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [BaseModule, TestHelper.getTypeOrmMysqlModule([BaseEntity])],
         }).compile();
@@ -25,7 +25,7 @@ describe('BaseController', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/base/base.controller.swagger.spec.ts
+++ b/spec/base/base.controller.swagger.spec.ts
@@ -14,7 +14,7 @@ describe('BaseController Swagger Decorator', () => {
     let controller: BaseController;
     let routeSet: Record<string, DenormalizedDoc>;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [BaseModule, TestHelper.getTypeOrmMysqlModule([BaseEntity])],
         }).compile();
@@ -29,13 +29,13 @@ describe('BaseController Swagger Decorator', () => {
         } as InstanceWrapper<BaseController>);
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });
 
     it('should generate api operation and response to ReadOne method', () => {
-        const readOne = 'BaseController_reservedReadOne';
+        const readOne = 'get /base/{id}';
         expect(routeSet[readOne].responses).toEqual({
             '200': {
                 content: expect.any(Object),
@@ -54,7 +54,8 @@ describe('BaseController Swagger Decorator', () => {
     });
 
     it('should generate api operation and response to ReadMany method', () => {
-        const readMany = 'BaseController_reservedReadMany';
+        const readMany = 'get /base';
+
         expect(routeSet[readMany].responses).toEqual({
             '200': {
                 content: expect.any(Object),
@@ -114,7 +115,7 @@ describe('BaseController Swagger Decorator', () => {
     });
 
     it('should generate api operation and response to Create method', () => {
-        const create = 'BaseController_reservedCreate';
+        const create = 'post /base';
         expect(routeSet[create].responses).toEqual({
             '201': {
                 description: 'Created ok',
@@ -137,7 +138,8 @@ describe('BaseController Swagger Decorator', () => {
     });
 
     it('should generate api operation and response to Delete method', () => {
-        const deleteKey = 'BaseController_reservedDelete';
+        const deleteKey = 'delete /base/{id}';
+
         expect(routeSet[deleteKey].responses).toEqual({
             '200': {
                 description: 'Deleted ok',
@@ -160,7 +162,7 @@ describe('BaseController Swagger Decorator', () => {
     });
 
     it('should generate api operation and response to Update method', () => {
-        const updateKey = 'BaseController_reservedUpdate';
+        const updateKey = 'patch /base/{id}';
         expect(routeSet[updateKey].responses).toEqual({
             '200': {
                 description: 'Updated ok',
@@ -183,7 +185,7 @@ describe('BaseController Swagger Decorator', () => {
     });
 
     it('should generate api operation and response to Upsert method', () => {
-        const updateKey = 'BaseController_reservedUpsert';
+        const updateKey = 'put /base/{id}';
         expect(routeSet[updateKey].responses).toEqual({
             '200': {
                 description: 'Upsert ok',
@@ -208,7 +210,7 @@ describe('BaseController Swagger Decorator', () => {
     });
 
     it('should generate api operation and response to Recover method', () => {
-        const recover = 'BaseController_reservedRecover';
+        const recover = 'post /base/{id}/recover';
         expect(routeSet[recover].responses).toEqual({
             '201': {
                 description: 'Recovered ok',
@@ -230,7 +232,7 @@ describe('BaseController Swagger Decorator', () => {
     });
 
     it('should generate api operation and response to Search method', () => {
-        const search = 'BaseController_reservedSearch';
+        const search = 'post /base/search';
         expect(routeSet[search].responses).toEqual({
             '200': {
                 content: expect.any(Object),

--- a/spec/base/base.controller.update.spec.ts
+++ b/spec/base/base.controller.update.spec.ts
@@ -9,7 +9,7 @@ import { TestHelper } from '../test.helper';
 describe('BaseController', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [BaseModule, TestHelper.getTypeOrmMysqlModule([BaseEntity])],
         }).compile();
@@ -18,7 +18,11 @@ describe('BaseController', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    beforeEach(async () => {
+        await BaseEntity.delete({});
+    });
+
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });
@@ -52,7 +56,7 @@ describe('BaseController', () => {
             expect(created.statusCode).toEqual(HttpStatus.CREATED);
             const id = created.body.id;
 
-            await new Promise((res) => setTimeout(res, 1000));
+            await new Promise((res) => setTimeout(res, 100));
             await request(app.getHttpServer()).patch(`/base/${id}`).send({ name: 'name2' }).expect(HttpStatus.OK);
 
             const readOne = await request(app.getHttpServer()).get(`/base/${id}`).expect(HttpStatus.OK);

--- a/spec/base/base.controller.upsert.spec.ts
+++ b/spec/base/base.controller.upsert.spec.ts
@@ -9,7 +9,7 @@ import { TestHelper } from '../test.helper';
 describe('BaseController', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [BaseModule, TestHelper.getTypeOrmMysqlModule([BaseEntity])],
         }).compile();
@@ -18,7 +18,11 @@ describe('BaseController', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    beforeEach(async () => {
+        await BaseEntity.delete({});
+    });
+
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/base/base.entity.ts
+++ b/spec/base/base.entity.ts
@@ -8,8 +8,8 @@ import { CrudAbstractEntity } from '../crud.abstract.entity';
 @Entity('base')
 export class BaseEntity extends CrudAbstractEntity {
     @Column({ nullable: true })
-    @IsString({ groups: [GROUP.CREATE, GROUP.UPDATE, GROUP.READ_MANY, GROUP.UPSERT, GROUP.PARAMS] })
-    @IsOptional({ groups: [GROUP.CREATE, GROUP.UPDATE, GROUP.READ_MANY, GROUP.UPSERT] })
+    @IsString({ groups: [GROUP.CREATE, GROUP.UPDATE, GROUP.READ_MANY, GROUP.UPSERT, GROUP.PARAMS, GROUP.SEARCH] })
+    @IsOptional({ groups: [GROUP.CREATE, GROUP.UPDATE, GROUP.READ_MANY, GROUP.UPSERT, GROUP.SEARCH] })
     name: string;
 
     @Column({ nullable: true })

--- a/spec/custom-entity/custom-entity.controller.create.spec.ts
+++ b/spec/custom-entity/custom-entity.controller.create.spec.ts
@@ -4,26 +4,21 @@ import request from 'supertest';
 
 import { CustomEntity } from './custom-entity.entity';
 import { CustomEntityModule } from './custom-entity.module';
-import { CustomEntityService } from './custom-entity.service';
 import { TestHelper } from '../test.helper';
 
 describe('CustomEntity - Create', () => {
     let app: INestApplication;
-    let service: CustomEntityService;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [CustomEntityModule, TestHelper.getTypeOrmMysqlModule([CustomEntity])],
         }).compile();
         app = moduleFixture.createNestApplication();
 
-        service = moduleFixture.get<CustomEntityService>(CustomEntityService);
-        await Promise.all(['name1', 'name2'].map((name: string) => service.repository.save(service.repository.create({ name }))));
-
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/custom-entity/custom-entity.controller.delete.spec.ts
+++ b/spec/custom-entity/custom-entity.controller.delete.spec.ts
@@ -4,26 +4,21 @@ import request from 'supertest';
 
 import { CustomEntity } from './custom-entity.entity';
 import { CustomEntityModule } from './custom-entity.module';
-import { CustomEntityService } from './custom-entity.service';
 import { TestHelper } from '../test.helper';
 
 describe('CustomEntity - Delete', () => {
     let app: INestApplication;
-    let service: CustomEntityService;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [CustomEntityModule, TestHelper.getTypeOrmMysqlModule([CustomEntity])],
         }).compile();
         app = moduleFixture.createNestApplication();
 
-        service = moduleFixture.get<CustomEntityService>(CustomEntityService);
-        await Promise.all(['name1', 'name2'].map((name: string) => service.repository.save(service.repository.create({ name }))));
-
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });
@@ -36,9 +31,9 @@ describe('CustomEntity - Delete', () => {
 
         it('removes one entity', async () => {
             const name = 'name1';
-            const created = await request(app.getHttpServer()).post('/base').send({ name });
-            expect(created.statusCode).toEqual(HttpStatus.CREATED);
-            const uuid = created.body.uuid;
+            const {
+                body: { uuid },
+            } = await request(app.getHttpServer()).post('/base').send({ name }).expect(HttpStatus.CREATED);
 
             await request(app.getHttpServer()).delete(`/base/${uuid}`).expect(HttpStatus.OK);
 

--- a/spec/custom-entity/custom-entity.controller.read-many.spec.ts
+++ b/spec/custom-entity/custom-entity.controller.read-many.spec.ts
@@ -1,6 +1,5 @@
 import { HttpStatus, INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import _ from 'lodash';
 import request from 'supertest';
 
 import { CustomEntity } from './custom-entity.entity';
@@ -12,7 +11,7 @@ describe('CustomEntity - ReadMany', () => {
     let app: INestApplication;
     let service: CustomEntityService;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [CustomEntityModule, TestHelper.getTypeOrmMysqlModule([CustomEntity])],
         }).compile();
@@ -20,13 +19,15 @@ describe('CustomEntity - ReadMany', () => {
 
         service = moduleFixture.get<CustomEntityService>(CustomEntityService);
         await Promise.all(
-            _.range(100).map((number) => service.repository.save(service.repository.create({ uuid: `${number}`, name: `name-${number}` }))),
+            Array.from({ length: 100 }, (_, index) => index).map((number) =>
+                service.repository.save(service.repository.create({ uuid: `${number}`, name: `name-${number}` })),
+            ),
         );
 
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/custom-entity/custom-entity.controller.read-many.spec.ts
+++ b/spec/custom-entity/custom-entity.controller.read-many.spec.ts
@@ -46,7 +46,6 @@ describe('CustomEntity - ReadMany', () => {
 
                 expect(response.statusCode).toEqual(HttpStatus.OK);
                 expect(response.body.data).toHaveLength(defaultLimit);
-                expect(response.body.metadata.nextCursor).toBeDefined();
                 expect(response.body.metadata.limit).toEqual(defaultLimit);
 
                 expect(response.body.data[0].uuid).toBeDefined();
@@ -57,12 +56,11 @@ describe('CustomEntity - ReadMany', () => {
             it('should return next 20 entities after cursor', async () => {
                 const firstResponse = await request(app.getHttpServer()).get('/base').expect(HttpStatus.OK);
                 const nextResponse = await request(app.getHttpServer()).get('/base').query({
-                    nextCursor: firstResponse.body.metadata.nextCursor,
+                    query: firstResponse.body.metadata.query,
                 });
 
                 expect(nextResponse.statusCode).toEqual(HttpStatus.OK);
                 expect(nextResponse.body.data).toHaveLength(defaultLimit);
-                expect(nextResponse.body.metadata.nextCursor).toBeDefined();
                 expect(nextResponse.body.metadata.limit).toEqual(defaultLimit);
 
                 expect(firstResponse.body.metadata.nextCursor).not.toEqual(nextResponse.body.metadata.nextCursor);

--- a/spec/custom-entity/custom-entity.controller.read-many.spec.ts
+++ b/spec/custom-entity/custom-entity.controller.read-many.spec.ts
@@ -56,7 +56,7 @@ describe('CustomEntity - ReadMany', () => {
             it('should return next 20 entities after cursor', async () => {
                 const firstResponse = await request(app.getHttpServer()).get('/base').expect(HttpStatus.OK);
                 const nextResponse = await request(app.getHttpServer()).get('/base').query({
-                    query: firstResponse.body.metadata.nextCursor,
+                    nextCursor: firstResponse.body.metadata.nextCursor,
                 });
 
                 expect(nextResponse.statusCode).toEqual(HttpStatus.OK);

--- a/spec/custom-entity/custom-entity.controller.read-many.spec.ts
+++ b/spec/custom-entity/custom-entity.controller.read-many.spec.ts
@@ -56,7 +56,7 @@ describe('CustomEntity - ReadMany', () => {
             it('should return next 20 entities after cursor', async () => {
                 const firstResponse = await request(app.getHttpServer()).get('/base').expect(HttpStatus.OK);
                 const nextResponse = await request(app.getHttpServer()).get('/base').query({
-                    query: firstResponse.body.metadata.query,
+                    query: firstResponse.body.metadata.nextCursor,
                 });
 
                 expect(nextResponse.statusCode).toEqual(HttpStatus.OK);

--- a/spec/custom-entity/custom-entity.controller.read-one.spec.ts
+++ b/spec/custom-entity/custom-entity.controller.read-one.spec.ts
@@ -11,7 +11,7 @@ describe('CustomEntity - ReadOne', () => {
     let app: INestApplication;
     let service: CustomEntityService;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [CustomEntityModule, TestHelper.getTypeOrmMysqlModule([CustomEntity])],
         }).compile();
@@ -23,14 +23,14 @@ describe('CustomEntity - ReadOne', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });
 
     describe('READ_ONE', () => {
         let id: string;
-        beforeEach(async () => {
+        beforeAll(async () => {
             id = (await service.getAll())?.[0]?.uuid;
         });
 

--- a/spec/custom-entity/custom-entity.controller.search.spec.ts
+++ b/spec/custom-entity/custom-entity.controller.search.spec.ts
@@ -1,6 +1,5 @@
 import { HttpStatus, INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import _ from 'lodash';
 import request from 'supertest';
 
 import { CustomEntity } from './custom-entity.entity';
@@ -12,7 +11,7 @@ describe('CustomEntity - Search', () => {
     let app: INestApplication;
     let service: CustomEntityService;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [CustomEntityModule, TestHelper.getTypeOrmMysqlModule([CustomEntity])],
         }).compile();
@@ -20,14 +19,16 @@ describe('CustomEntity - Search', () => {
 
         service = moduleFixture.get<CustomEntityService>(CustomEntityService);
         await Promise.all(
-            _.range(100).map((number) => service.repository.save(service.repository.create({ uuid: `${number}`, name: `name-${number}` }))),
+            Array.from({ length: 100 }, (_, index) => index).map((number) =>
+                service.repository.save(service.repository.create({ uuid: `${number}`, name: `name-${number}` })),
+            ),
         );
 
         await service.repository.save(service.repository.create({ uuid: 'test' }));
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/custom-entity/custom-entity.controller.update.spec.ts
+++ b/spec/custom-entity/custom-entity.controller.update.spec.ts
@@ -4,26 +4,21 @@ import request from 'supertest';
 
 import { CustomEntity } from './custom-entity.entity';
 import { CustomEntityModule } from './custom-entity.module';
-import { CustomEntityService } from './custom-entity.service';
 import { TestHelper } from '../test.helper';
 
 describe('CustomEntity - Update', () => {
     let app: INestApplication;
-    let service: CustomEntityService;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [CustomEntityModule, TestHelper.getTypeOrmMysqlModule([CustomEntity])],
         }).compile();
         app = moduleFixture.createNestApplication();
 
-        service = moduleFixture.get<CustomEntityService>(CustomEntityService);
-        await Promise.all(['name1', 'name2'].map((name: string) => service.repository.save(service.repository.create({ name }))));
-
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/custom-entity/custom-entity.controller.upsert.spec.ts
+++ b/spec/custom-entity/custom-entity.controller.upsert.spec.ts
@@ -4,26 +4,21 @@ import request from 'supertest';
 
 import { CustomEntity } from './custom-entity.entity';
 import { CustomEntityModule } from './custom-entity.module';
-import { CustomEntityService } from './custom-entity.service';
 import { TestHelper } from '../test.helper';
 
 describe('CustomEntity - Upsert', () => {
     let app: INestApplication;
-    let service: CustomEntityService;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [CustomEntityModule, TestHelper.getTypeOrmMysqlModule([CustomEntity])],
         }).compile();
         app = moduleFixture.createNestApplication();
 
-        service = moduleFixture.get<CustomEntityService>(CustomEntityService);
-        await Promise.all(['name1', 'name2'].map((name: string) => service.repository.save(service.repository.create({ name }))));
-
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/custom-swagger-decorator/apply-api-extra-model.spec.ts
+++ b/spec/custom-swagger-decorator/apply-api-extra-model.spec.ts
@@ -10,7 +10,7 @@ import { TestHelper } from '../test.helper';
 describe('Apply ApiExtraModels Decorator', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [DynamicCrudModule({ readMany: { decorators: [ApiExtraModels(ExtraModel)] } })],
         }).compile();
@@ -20,7 +20,7 @@ describe('Apply ApiExtraModels Decorator', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/custom-swagger-decorator/without-custom-decorator.spec.ts
+++ b/spec/custom-swagger-decorator/without-custom-decorator.spec.ts
@@ -9,7 +9,7 @@ import { TestHelper } from '../test.helper';
 describe('No custom Swagger Decorator', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [DynamicCrudModule({ readMany: { decorators: [] } })],
         }).compile();
@@ -19,7 +19,7 @@ describe('No custom Swagger Decorator', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/exclude-swagger/exclude-swagger.spec.ts
+++ b/spec/exclude-swagger/exclude-swagger.spec.ts
@@ -14,7 +14,7 @@ describe('exclude swagger by route', () => {
     let controller: ExcludeSwaggerController;
     let routeSet: Record<string, DenormalizedDoc>;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [ExcludeSwaggerModule, TestHelper.getTypeOrmMysqlModule([BaseEntity])],
         }).compile();
@@ -30,18 +30,18 @@ describe('exclude swagger by route', () => {
         } as InstanceWrapper<ExcludeSwaggerController>);
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });
 
     it('should not generate recover route in swagger', async () => {
-        const recover = 'HideSwaggerController_reservedRecover';
+        const recover = 'post /exclude-swagger/{id}/recover';
         expect(routeSet[recover]).toBeUndefined();
     });
 
     it('Should be changed swagger readOne response interface', () => {
-        const readOne = 'ExcludeSwaggerController_reservedReadOne';
+        const readOne = 'get /exclude-swagger/{id}';
         expect(routeSet[readOne].responses).toEqual({
             '200': {
                 content: {
@@ -64,7 +64,7 @@ describe('exclude swagger by route', () => {
     });
 
     it('Should be changed swagger update response interface', () => {
-        const update = 'ExcludeSwaggerController_reservedUpdate';
+        const update = 'patch /exclude-swagger/{id}';
         expect(routeSet[update].responses).toEqual({
             '200': {
                 content: {
@@ -87,7 +87,7 @@ describe('exclude swagger by route', () => {
     });
 
     it('Should be changed swagger Create request body interface', () => {
-        const create = 'ExcludeSwaggerController_reservedCreate';
+        const create = 'post /exclude-swagger';
         expect(routeSet[create].root).toEqual({
             method: 'post',
             path: '/exclude-swagger',

--- a/spec/logging/logging.spec.ts
+++ b/spec/logging/logging.spec.ts
@@ -4,7 +4,6 @@ import { Controller, Injectable, Module } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { InjectRepository, TypeOrmModule } from '@nestjs/typeorm';
 import { IsOptional } from 'class-validator';
-import _ from 'lodash';
 import request from 'supertest';
 import { Entity, BaseEntity, Repository, PrimaryColumn, Column, DeleteDateColumn } from 'typeorm';
 
@@ -53,7 +52,7 @@ describe('Logging', () => {
     let app: INestApplication;
     let loggerSpy: jest.SpyInstance;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [TestModule, TestHelper.getTypeOrmPgsqlModule([TestEntity])],
         })
@@ -65,7 +64,7 @@ describe('Logging', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });
@@ -84,11 +83,11 @@ describe('Logging', () => {
                 _findOptions: {
                     where: {},
                     take: 20,
-                    withDeleted: false,
                     order: { col1: 'DESC' },
+                    withDeleted: false,
                     relations: [],
                 },
-                _pagination: { type: 'cursor' },
+                _pagination: { _isNext: false, type: 'cursor', _where: btoa('{}') },
                 _sort: 'DESC',
             }),
             'CRUD GET /base',

--- a/spec/mongodb/mongodb.spec.ts
+++ b/spec/mongodb/mongodb.spec.ts
@@ -66,7 +66,7 @@ describe('mongodb', () => {
     let mongod: MongoMemoryServer;
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         mongod = await MongoMemoryServer.create();
         const mongoUri = mongod.getUri();
 
@@ -77,7 +77,7 @@ describe('mongodb', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await mongod?.stop();
         await app?.close();
     });

--- a/spec/multiple-primary-key/multiple-primary-key.controller.create.spec.ts
+++ b/spec/multiple-primary-key/multiple-primary-key.controller.create.spec.ts
@@ -4,26 +4,21 @@ import request from 'supertest';
 
 import { MultiplePrimaryKeyEntity } from './multiple-primary-key.entity';
 import { MultiplePrimaryKeyModule } from './multiple-primary-key.module';
-import { MultiplePrimaryKeyService } from './multiple-primary-key.service';
 import { TestHelper } from '../test.helper';
 
 describe('MultiplePrimaryKey - Create', () => {
     let app: INestApplication;
-    let service: MultiplePrimaryKeyService;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [MultiplePrimaryKeyModule, TestHelper.getTypeOrmMysqlModule([MultiplePrimaryKeyEntity])],
         }).compile();
         app = moduleFixture.createNestApplication();
 
-        service = moduleFixture.get<MultiplePrimaryKeyService>(MultiplePrimaryKeyService);
-        await Promise.all(['name1', 'name2'].map((name: string) => service.repository.save(service.repository.create({ name }))));
-
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/multiple-primary-key/multiple-primary-key.controller.delete.spec.ts
+++ b/spec/multiple-primary-key/multiple-primary-key.controller.delete.spec.ts
@@ -4,26 +4,21 @@ import request from 'supertest';
 
 import { MultiplePrimaryKeyEntity } from './multiple-primary-key.entity';
 import { MultiplePrimaryKeyModule } from './multiple-primary-key.module';
-import { MultiplePrimaryKeyService } from './multiple-primary-key.service';
 import { TestHelper } from '../test.helper';
 
 describe('MultiplePrimaryKey - Delete', () => {
     let app: INestApplication;
-    let service: MultiplePrimaryKeyService;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [MultiplePrimaryKeyModule, TestHelper.getTypeOrmMysqlModule([MultiplePrimaryKeyEntity])],
         }).compile();
         app = moduleFixture.createNestApplication();
 
-        service = moduleFixture.get<MultiplePrimaryKeyService>(MultiplePrimaryKeyService);
-        await Promise.all(['name1', 'name2'].map((name: string) => service.repository.save(service.repository.create({ name }))));
-
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/multiple-primary-key/multiple-primary-key.controller.read-one.spec.ts
+++ b/spec/multiple-primary-key/multiple-primary-key.controller.read-one.spec.ts
@@ -11,7 +11,7 @@ describe('MultiplePrimaryKey - ReadOne', () => {
     let app: INestApplication;
     let service: MultiplePrimaryKeyService;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [MultiplePrimaryKeyModule, TestHelper.getTypeOrmMysqlModule([MultiplePrimaryKeyEntity])],
         }).compile();
@@ -23,14 +23,14 @@ describe('MultiplePrimaryKey - ReadOne', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });
 
     describe('READ_ONE', () => {
         let entity: MultiplePrimaryKeyEntity;
-        beforeEach(async () => {
+        beforeAll(async () => {
             entity = (await service.getAll())?.[0];
         });
 

--- a/spec/multiple-primary-key/multiple-primary-key.controller.recover.spec.ts
+++ b/spec/multiple-primary-key/multiple-primary-key.controller.recover.spec.ts
@@ -12,7 +12,7 @@ describe('MultiplePrimaryKey - Recover', () => {
     let service: MultiplePrimaryKeyService;
     let entities: MultiplePrimaryKeyEntity[];
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [MultiplePrimaryKeyModule, TestHelper.getTypeOrmMysqlModule([MultiplePrimaryKeyEntity])],
         }).compile();
@@ -26,7 +26,7 @@ describe('MultiplePrimaryKey - Recover', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });
@@ -41,20 +41,15 @@ describe('MultiplePrimaryKey - Recover', () => {
             const { uuid1, uuid2 } = entities[0];
             await request(app.getHttpServer()).get(`/base/${uuid1}/${uuid2}`).expect(HttpStatus.OK);
 
-            // Delete
             await request(app.getHttpServer()).delete(`/base/${uuid1}/${uuid2}`).expect(HttpStatus.OK);
 
-            // getOne -> NotFOUND
             await request(app.getHttpServer()).get(`/base/${uuid1}/${uuid2}`).expect(HttpStatus.NOT_FOUND);
 
-            // getMany -> id가 없다.
             const { body } = await request(app.getHttpServer()).get('/base').expect(HttpStatus.OK);
             expect(body.data.some((entity: MultiplePrimaryKeyEntity) => entity.uuid1 === uuid1 && entity.uuid2 === uuid2)).toBeFalsy();
 
-            // Recover
             await request(app.getHttpServer()).post(`/base/${uuid1}/${uuid2}/recover`).expect(HttpStatus.CREATED);
 
-            // GetOne -> OK
             await request(app.getHttpServer()).get(`/base/${uuid1}/${uuid2}`).expect(HttpStatus.OK);
         });
     });

--- a/spec/multiple-primary-key/multiple-primary-key.controller.upsert.spec.ts
+++ b/spec/multiple-primary-key/multiple-primary-key.controller.upsert.spec.ts
@@ -9,7 +9,7 @@ import { TestHelper } from '../test.helper';
 describe('MultiplePrimaryKey - Upsert', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [MultiplePrimaryKeyModule, TestHelper.getTypeOrmMysqlModule([MultiplePrimaryKeyEntity])],
         }).compile();
@@ -18,7 +18,7 @@ describe('MultiplePrimaryKey - Upsert', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/pagination/pagination.interceptor.spec.ts
+++ b/spec/pagination/pagination.interceptor.spec.ts
@@ -67,8 +67,11 @@ describe('Pagination with interceptor', () => {
 
             const {
                 body: responseBodyAfterDelete,
-            }: { body: { data: Array<{ id: number; deletedAt?: unknown }>; metadata: { nextCursor: unknown; query: unknown } } } =
-                await request(app.getHttpServer()).get(`/${PaginationType.CURSOR}`).expect(HttpStatus.OK);
+            }: { body: { data: Array<{ id: number; deletedAt?: unknown }>; metadata: { nextCursor: unknown } } } = await request(
+                app.getHttpServer(),
+            )
+                .get(`/${PaginationType.CURSOR}`)
+                .expect(HttpStatus.OK);
             const { body: offsetResponseBodyAfterDelete } = await request(app.getHttpServer())
                 .get(`/${PaginationType.OFFSET}`)
                 .expect(HttpStatus.OK);
@@ -91,13 +94,13 @@ describe('Pagination with interceptor', () => {
             const { body: nextResponseBody } = await request(app.getHttpServer())
                 .get(`/${PaginationType.CURSOR}`)
                 .query({
-                    query: responseBodyAfterDelete.metadata.nextCursor,
+                    nextCursor: responseBodyAfterDelete.metadata.nextCursor,
                 })
                 .expect(HttpStatus.OK);
             const { body: offsetNextResponseBody } = await request(app.getHttpServer())
                 .get(`/${PaginationType.OFFSET}`)
                 .query({
-                    query: offsetResponseBodyAfterDelete.metadata.nextCursor,
+                    nextCursor: offsetResponseBodyAfterDelete.metadata.nextCursor,
                     offset: offsetResponseBodyAfterDelete.metadata.offset,
                 })
                 .expect(HttpStatus.OK);

--- a/spec/pagination/pagination.interceptor.spec.ts
+++ b/spec/pagination/pagination.interceptor.spec.ts
@@ -1,6 +1,5 @@
 import { HttpStatus, INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import _ from 'lodash';
 import request from 'supertest';
 
 import { PaginationModule } from './pagination.module';
@@ -14,7 +13,7 @@ describe('Pagination with interceptor', () => {
     describe('with ReadMany Interceptor', () => {
         let app: INestApplication;
 
-        beforeEach(async () => {
+        beforeAll(async () => {
             const moduleFixture: TestingModule = await Test.createTestingModule({
                 imports: [
                     PaginationModule({
@@ -36,17 +35,21 @@ describe('Pagination with interceptor', () => {
             app = moduleFixture.createNestApplication();
 
             const service: BaseService = moduleFixture.get<BaseService>(BaseService);
-            await Promise.all(_.range(100).map((number) => service.repository.save(service.repository.create({ name: `name-${number}` }))));
+            await Promise.all(
+                Array.from({ length: 100 }, (_, index) => index).map((number) =>
+                    service.repository.save(service.repository.create({ name: `name-${number}` })),
+                ),
+            );
             await app.init();
         });
 
-        afterEach(async () => {
+        afterAll(async () => {
             await TestHelper.dropTypeOrmEntityTables();
             await app?.close();
         });
 
         it('should be returned deleted entities each interceptor soft-deleted option', async () => {
-            const deleteIdList: number[] = _.range(1, 101).filter((number) => number % 2 === 0);
+            const deleteIdList: number[] = Array.from({ length: 100 }, (_, index) => index + 1).filter((number) => number % 2 === 0);
             const { body: responseBodyBeforeDelete } = await request(app.getHttpServer())
                 .get(`/${PaginationType.CURSOR}`)
                 .expect(HttpStatus.OK);
@@ -114,7 +117,7 @@ describe('Pagination with interceptor', () => {
     describe('without ReadMany Interceptor', () => {
         let app: INestApplication;
 
-        beforeEach(async () => {
+        beforeAll(async () => {
             const moduleFixture: TestingModule = await Test.createTestingModule({
                 imports: [
                     PaginationModule({
@@ -136,11 +139,15 @@ describe('Pagination with interceptor', () => {
             app = moduleFixture.createNestApplication();
 
             const service: BaseService = moduleFixture.get<BaseService>(BaseService);
-            await Promise.all(_.range(100).map((number) => service.repository.save(service.repository.create({ name: `name-${number}` }))));
+            await Promise.all(
+                Array.from({ length: 100 }, (_, index) => index).map((number) =>
+                    service.repository.save(service.repository.create({ name: `name-${number}` })),
+                ),
+            );
             await app.init();
         });
 
-        afterEach(async () => {
+        afterAll(async () => {
             await TestHelper.dropTypeOrmEntityTables();
             await app?.close();
         });

--- a/spec/pagination/pagination.interceptor.spec.ts
+++ b/spec/pagination/pagination.interceptor.spec.ts
@@ -91,14 +91,13 @@ describe('Pagination with interceptor', () => {
             const { body: nextResponseBody } = await request(app.getHttpServer())
                 .get(`/${PaginationType.CURSOR}`)
                 .query({
-                    nextCursor: responseBodyAfterDelete.metadata.nextCursor,
-                    query: responseBodyAfterDelete.metadata.query,
+                    query: responseBodyAfterDelete.metadata.nextCursor,
                 })
                 .expect(HttpStatus.OK);
             const { body: offsetNextResponseBody } = await request(app.getHttpServer())
                 .get(`/${PaginationType.OFFSET}`)
                 .query({
-                    query: offsetResponseBodyAfterDelete.metadata.query,
+                    query: offsetResponseBodyAfterDelete.metadata.nextCursor,
                     offset: offsetResponseBodyAfterDelete.metadata.offset,
                 })
                 .expect(HttpStatus.OK);

--- a/spec/pagination/pagination.spec.ts
+++ b/spec/pagination/pagination.spec.ts
@@ -185,19 +185,6 @@ describe('Pagination', () => {
             expect((responseBody.data as Array<{ id: string }>).some(({ id }) => nextDataIds.has(id))).not.toBeTruthy();
         });
 
-        it('should throw when offset pagination query provided', async () => {
-            const { body: responseBody } = await request(app.getHttpServer()).get(`/${PaginationType.OFFSET}`).expect(HttpStatus.OK);
-
-            await request(app.getHttpServer())
-                .get(`/${PaginationType.CURSOR}`)
-                .query({
-                    query: responseBody.metadata.query,
-                    offset: responseBody.metadata.offset,
-                    limit: 15,
-                })
-                .expect(HttpStatus.UNPROCESSABLE_ENTITY);
-        });
-
         it('should be calculate the number of entities', async () => {
             const {
                 body: { metadata: metadataAll },

--- a/spec/pagination/pagination.spec.ts
+++ b/spec/pagination/pagination.spec.ts
@@ -72,22 +72,20 @@ describe('Pagination', () => {
         expect(cursorResponseBody.metadata).toEqual({
             nextCursor: expect.any(String),
             limit: defaultLimit,
-            query: expect.any(String),
             total: 1,
         });
-        expect(offsetResponseBody.metadata).toEqual({ page: 1, pages: 1, total: 1, offset: 1, query: expect.any(String) });
+        expect(offsetResponseBody.metadata).toEqual({ page: 1, pages: 1, total: 1, offset: 1, nextCursor: expect.any(String) });
 
         const { body: nextResponseBody } = await request(app.getHttpServer())
             .get(`/${PaginationType.CURSOR}`)
             .query({
-                nextCursor: cursorResponseBody.metadata.nextCursor,
-                query: cursorResponseBody.metadata.query,
+                query: cursorResponseBody.metadata.nextCursor,
             })
             .expect(HttpStatus.OK);
         const { body: offsetNextResponseBody } = await request(app.getHttpServer())
             .get(`/${PaginationType.OFFSET}`)
             .query({
-                query: offsetResponseBody.metadata.query,
+                query: offsetResponseBody.metadata.nextCursor,
                 offset: offsetResponseBody.metadata.offset,
             })
             .expect(HttpStatus.OK);
@@ -96,7 +94,7 @@ describe('Pagination', () => {
         expect(nextResponseBody.data).toHaveLength(0);
         expect(nextResponseBody.metadata.nextCursor).not.toEqual(cursorResponseBody.metadata.nextCursor);
         expect(nextResponseBody.metadata.limit).toEqual(20);
-        expect(offsetNextResponseBody.metadata).toEqual({ page: 1, pages: 1, total: 1, offset: 1, query: expect.any(String) });
+        expect(offsetNextResponseBody.metadata).toEqual({ page: 1, pages: 1, total: 1, offset: 1, nextCursor: expect.any(String) });
     });
 
     describe('Cursor', () => {
@@ -107,7 +105,6 @@ describe('Pagination', () => {
             expect(cursorBody.metadata).toEqual({
                 nextCursor: expect.any(String),
                 limit: defaultLimit,
-                query: expect.any(String),
                 total: totalCount,
             });
         });
@@ -118,8 +115,7 @@ describe('Pagination', () => {
             const { body: nextResponseBody } = await request(app.getHttpServer())
                 .get(`/${PaginationType.CURSOR}`)
                 .query({
-                    nextCursor: firstResponseBody.metadata.nextCursor,
-                    query: firstResponseBody.metadata.query,
+                    query: firstResponseBody.metadata.nextCursor,
                 })
                 .expect(HttpStatus.OK);
 
@@ -129,7 +125,6 @@ describe('Pagination', () => {
             expect(nextResponseBody.metadata).toEqual({
                 nextCursor: expect.any(String),
                 limit: defaultLimit,
-                query: expect.any(String),
                 total: totalCount - defaultLimit,
             });
 
@@ -157,15 +152,13 @@ describe('Pagination', () => {
             expect(responseBody.metadata).toEqual({
                 nextCursor: expect.any(String),
                 limit: defaultLimit,
-                query: expect.any(String),
                 total: totalCount,
             });
 
             const { body: nextResponseBody } = await request(app.getHttpServer())
                 .get(`/${PaginationType.CURSOR}`)
                 .query({
-                    nextCursor: responseBody.metadata.nextCursor,
-                    query: responseBody.metadata.query,
+                    query: responseBody.metadata.nextCursor,
                 })
                 .expect(HttpStatus.OK);
 
@@ -173,7 +166,6 @@ describe('Pagination', () => {
             expect(nextResponseBody.metadata).toEqual({
                 nextCursor: expect.any(String),
                 limit: defaultLimit,
-                query: expect.any(String),
                 total: totalCount - defaultLimit,
             });
             expect(nextResponseBody.metadata.nextCursor).not.toEqual(responseBody.metadata.nextCursor);
@@ -207,11 +199,11 @@ describe('Pagination', () => {
         it('should return 20 entities as default', async () => {
             const { body } = await request(app.getHttpServer()).get(`/${PaginationType.OFFSET}`).expect(HttpStatus.OK);
             expect(body.data).toHaveLength(defaultLimit);
-            expect(body.metadata).toEqual({ page: 1, pages: 5, total: 100, offset: defaultLimit, query: expect.any(String) });
+            expect(body.metadata).toEqual({ page: 1, pages: 5, total: 100, offset: defaultLimit, nextCursor: expect.any(String) });
 
             const { body: searchBody } = await request(app.getHttpServer()).post(`/${PaginationType.OFFSET}/search`).expect(HttpStatus.OK);
             expect(searchBody.data).toHaveLength(defaultLimit);
-            expect(searchBody.metadata).toEqual({ page: 1, pages: 5, total: 100, offset: defaultLimit, query: expect.any(String) });
+            expect(searchBody.metadata).toEqual({ page: 1, pages: 5, total: 100, offset: defaultLimit, nextCursor: expect.any(String) });
         });
 
         it('should return next page from offset on readMany', async () => {
@@ -220,7 +212,7 @@ describe('Pagination', () => {
             const { body: nextResponseBody } = await request(app.getHttpServer())
                 .get(`/${PaginationType.OFFSET}`)
                 .query({
-                    query: firstResponseBody.metadata.query,
+                    query: firstResponseBody.metadata.nextCursor,
                     offset: firstResponseBody.metadata.offset,
                 })
                 .expect(HttpStatus.OK);
@@ -230,7 +222,7 @@ describe('Pagination', () => {
                 pages: 5,
                 total: 100,
                 offset: defaultLimit,
-                query: expect.any(String),
+                nextCursor: expect.any(String),
             });
 
             expect(nextResponseBody.metadata).toEqual({
@@ -238,7 +230,7 @@ describe('Pagination', () => {
                 pages: 5,
                 total: 100,
                 offset: defaultLimit * 2,
-                query: expect.any(String),
+                nextCursor: expect.any(String),
             });
         });
 
@@ -250,7 +242,7 @@ describe('Pagination', () => {
             const { body: nextResponseBody } = await request(app.getHttpServer())
                 .post(`/${PaginationType.OFFSET}/search`)
                 .send({
-                    query: firstResponseBody.metadata.query,
+                    query: firstResponseBody.metadata.nextCursor,
                     offset: firstResponseBody.metadata.offset,
                 })
                 .expect(HttpStatus.OK);
@@ -260,7 +252,7 @@ describe('Pagination', () => {
                 pages: 5,
                 total: 100,
                 offset: defaultLimit,
-                query: expect.any(String),
+                nextCursor: expect.any(String),
             });
 
             expect(nextResponseBody.metadata).toEqual({
@@ -268,7 +260,7 @@ describe('Pagination', () => {
                 pages: 5,
                 total: 100,
                 offset: defaultLimit * 2,
-                query: expect.any(String),
+                nextCursor: expect.any(String),
             });
         });
 
@@ -288,7 +280,7 @@ describe('Pagination', () => {
             const { body: readManyNextResponseBody } = await request(app.getHttpServer())
                 .get(`/${PaginationType.OFFSET}`)
                 .query({
-                    query: readManyResponseBody.metadata.query,
+                    query: readManyResponseBody.metadata.nextCursor,
                     offset: readManyResponseBody.metadata.offset,
                 })
                 .expect(HttpStatus.OK);
@@ -298,14 +290,14 @@ describe('Pagination', () => {
                 pages: 5,
                 total: 100,
                 offset: 20,
-                query: expect.any(String),
+                nextCursor: expect.any(String),
             });
             expect(readManyNextResponseBody.metadata).toEqual({
                 page: 2,
                 pages: 5,
                 total: 100,
                 offset: 40,
-                query: expect.any(String),
+                nextCursor: expect.any(String),
             });
 
             // search
@@ -321,14 +313,14 @@ describe('Pagination', () => {
 
             const { body: searchNextResponseBody } = await request(app.getHttpServer())
                 .post(`/${PaginationType.OFFSET}/search`)
-                .send({ query: searchResponseBody.metadata.query, offset: searchResponseBody.metadata.offset })
+                .send({ query: searchResponseBody.metadata.nextCursor, offset: searchResponseBody.metadata.offset })
                 .expect(HttpStatus.OK);
             expect(searchNextResponseBody.metadata).toEqual({
                 page: 2,
                 pages: 5,
                 total: 100,
                 offset: 40,
-                query: expect.any(String),
+                nextCursor: expect.any(String),
             });
 
             for (const data of searchNextResponseBody.data) {
@@ -338,14 +330,14 @@ describe('Pagination', () => {
 
             const { body: searchNextNextResponseBody } = await request(app.getHttpServer())
                 .post(`/${PaginationType.OFFSET}/search`)
-                .send({ query: searchNextResponseBody.metadata.query, offset: searchNextResponseBody.metadata.offset })
+                .send({ query: searchNextResponseBody.metadata.nextCursor, offset: searchNextResponseBody.metadata.offset })
                 .expect(HttpStatus.OK);
             expect(searchNextNextResponseBody.metadata).toEqual({
                 page: 3,
                 pages: 5,
                 total: 100,
                 offset: 60,
-                query: expect.any(String),
+                nextCursor: expect.any(String),
             });
             for (const data of searchNextResponseBody.data) {
                 expect(data.name).toEqual('same name');
@@ -360,12 +352,12 @@ describe('Pagination', () => {
                 .query({ limit })
                 .expect(HttpStatus.OK);
             expect(responseBody.data).toHaveLength(limit);
-            expect(responseBody.metadata).toEqual({ page: 1, pages: 7, total: 100, offset: limit, query: expect.any(String) });
+            expect(responseBody.metadata).toEqual({ page: 1, pages: 7, total: 100, offset: limit, nextCursor: expect.any(String) });
 
             const { body: nextResponseBody } = await request(app.getHttpServer())
                 .get(`/${PaginationType.OFFSET}`)
                 .query({
-                    query: responseBody.metadata.query,
+                    query: responseBody.metadata.nextCursor,
                     offset: responseBody.metadata.offset,
                     limit,
                 })
@@ -376,7 +368,7 @@ describe('Pagination', () => {
                 pages: 7,
                 total: 100,
                 offset: limit * 2,
-                query: expect.any(String),
+                nextCursor: expect.any(String),
             });
         });
 
@@ -386,7 +378,7 @@ describe('Pagination', () => {
             const { body: nextResponseBody } = await request(app.getHttpServer())
                 .get(`/${PaginationType.OFFSET}`)
                 .query({
-                    query: firstResponseBody.metadata.query,
+                    query: firstResponseBody.metadata.nextCursor,
                     offset: firstResponseBody.metadata.offset,
                     limit,
                 })
@@ -394,13 +386,19 @@ describe('Pagination', () => {
 
             expect(firstResponseBody.data).toHaveLength(defaultLimit);
             expect(nextResponseBody.data).toHaveLength(limit);
-            expect(firstResponseBody.metadata).toEqual({ page: 1, pages: 5, total: 100, offset: defaultLimit, query: expect.any(String) });
+            expect(firstResponseBody.metadata).toEqual({
+                page: 1,
+                pages: 5,
+                total: 100,
+                offset: defaultLimit,
+                nextCursor: expect.any(String),
+            });
             expect(nextResponseBody.metadata).toEqual({
                 page: 2,
                 pages: Math.ceil(100 / limit),
                 total: 100,
                 offset: defaultLimit + limit,
-                query: expect.any(String),
+                nextCursor: expect.any(String),
             });
 
             const lastOneOfFirstResponse = firstResponseBody.data.pop();

--- a/spec/pagination/pagination.spec.ts
+++ b/spec/pagination/pagination.spec.ts
@@ -1,6 +1,5 @@
 import { ConsoleLogger, HttpStatus, INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import _ from 'lodash';
 import request from 'supertest';
 
 import { PaginationModule } from './pagination.module';
@@ -14,14 +13,14 @@ describe('Pagination', () => {
     const totalCount = 100;
     const defaultLimit = 20;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const logger = new ConsoleLogger();
         logger.setLogLevels(['error']);
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [
                 PaginationModule({
-                    cursor: { readMany: { paginationType: 'cursor' } },
-                    offset: { readMany: { paginationType: 'offset' } },
+                    cursor: { readMany: { paginationType: 'cursor' }, search: { paginationType: 'cursor' } },
+                    offset: { readMany: { paginationType: 'offset' }, search: { paginationType: 'offset' } },
                 }),
             ],
         })
@@ -30,13 +29,19 @@ describe('Pagination', () => {
         app = moduleFixture.createNestApplication();
 
         service = moduleFixture.get<BaseService>(BaseService);
-        await Promise.all(
-            _.range(totalCount).map((number) => service.repository.save(service.repository.create({ name: `name-${number}` }))),
-        );
         await app.init();
     });
 
-    afterEach(async () => {
+    beforeEach(async () => {
+        await service.repository.delete({});
+        await Promise.all(
+            Array.from({ length: totalCount }, (_, index) => index).map((number) =>
+                service.repository.save(service.repository.create({ name: `name-${number}` })),
+            ),
+        );
+    });
+
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });
@@ -91,7 +96,6 @@ describe('Pagination', () => {
         expect(nextResponseBody.data).toHaveLength(0);
         expect(nextResponseBody.metadata.nextCursor).not.toEqual(cursorResponseBody.metadata.nextCursor);
         expect(nextResponseBody.metadata.limit).toEqual(20);
-        expect(nextResponseBody.metadata.query).toEqual(cursorResponseBody.metadata.query);
         expect(offsetNextResponseBody.metadata).toEqual({ page: 1, pages: 1, total: 1, offset: 1, query: expect.any(String) });
     });
 
@@ -137,7 +141,7 @@ describe('Pagination', () => {
 
         it('should be keep query condition to next request', async () => {
             await Promise.all(
-                _.range(100).map((_n) =>
+                Array.from({ length: 100 }).map((_) =>
                     request(app.getHttpServer()).post(`/${PaginationType.CURSOR}`).send({ name: 'same name' }).expect(HttpStatus.CREATED),
                 ),
             );
@@ -169,7 +173,7 @@ describe('Pagination', () => {
             expect(nextResponseBody.metadata).toEqual({
                 nextCursor: expect.any(String),
                 limit: defaultLimit,
-                query: responseBody.metadata.query,
+                query: expect.any(String),
                 total: totalCount - defaultLimit,
             });
             expect(nextResponseBody.metadata.nextCursor).not.toEqual(responseBody.metadata.nextCursor);
@@ -217,9 +221,13 @@ describe('Pagination', () => {
             const { body } = await request(app.getHttpServer()).get(`/${PaginationType.OFFSET}`).expect(HttpStatus.OK);
             expect(body.data).toHaveLength(defaultLimit);
             expect(body.metadata).toEqual({ page: 1, pages: 5, total: 100, offset: defaultLimit, query: expect.any(String) });
+
+            const { body: searchBody } = await request(app.getHttpServer()).post(`/${PaginationType.OFFSET}/search`).expect(HttpStatus.OK);
+            expect(searchBody.data).toHaveLength(defaultLimit);
+            expect(searchBody.metadata).toEqual({ page: 1, pages: 5, total: 100, offset: defaultLimit, query: expect.any(String) });
         });
 
-        it('should return next page from offset', async () => {
+        it('should return next page from offset on readMany', async () => {
             const { body: firstResponseBody } = await request(app.getHttpServer()).get(`/${PaginationType.OFFSET}`).expect(HttpStatus.OK);
 
             const { body: nextResponseBody } = await request(app.getHttpServer())
@@ -247,27 +255,115 @@ describe('Pagination', () => {
             });
         });
 
+        it('should return next page from offset on search', async () => {
+            const { body: firstResponseBody } = await request(app.getHttpServer())
+                .post(`/${PaginationType.OFFSET}/search`)
+                .expect(HttpStatus.OK);
+
+            const { body: nextResponseBody } = await request(app.getHttpServer())
+                .post(`/${PaginationType.OFFSET}/search`)
+                .send({
+                    query: firstResponseBody.metadata.query,
+                    offset: firstResponseBody.metadata.offset,
+                })
+                .expect(HttpStatus.OK);
+
+            expect(firstResponseBody.metadata).toEqual({
+                page: 1,
+                pages: 5,
+                total: 100,
+                offset: defaultLimit,
+                query: expect.any(String),
+            });
+
+            expect(nextResponseBody.metadata).toEqual({
+                page: 2,
+                pages: 5,
+                total: 100,
+                offset: defaultLimit * 2,
+                query: expect.any(String),
+            });
+        });
+
         it('should be keep query condition to next request', async () => {
             await Promise.all(
-                _.range(100).map((_n) =>
+                Array.from({ length: 100 }).map((_) =>
                     request(app.getHttpServer()).post(`/${PaginationType.OFFSET}`).send({ name: 'same name' }).expect(HttpStatus.CREATED),
                 ),
             );
 
-            const { body: responseBody } = await request(app.getHttpServer())
+            // readMany
+            const { body: readManyResponseBody } = await request(app.getHttpServer())
                 .get(`/${PaginationType.OFFSET}`)
                 .query({ name: 'same name' })
                 .expect(HttpStatus.OK);
 
-            const { body: nextResponseBody } = await request(app.getHttpServer())
+            const { body: readManyNextResponseBody } = await request(app.getHttpServer())
                 .get(`/${PaginationType.OFFSET}`)
                 .query({
-                    query: responseBody.metadata.query,
-                    offset: responseBody.metadata.offset,
+                    query: readManyResponseBody.metadata.query,
+                    offset: readManyResponseBody.metadata.offset,
                 })
                 .expect(HttpStatus.OK);
 
-            expect(nextResponseBody.metadata).toHaveProperty('query', responseBody.metadata.query);
+            expect(readManyResponseBody.metadata).toEqual({
+                page: 1,
+                pages: 5,
+                total: 100,
+                offset: 20,
+                query: expect.any(String),
+            });
+            expect(readManyNextResponseBody.metadata).toEqual({
+                page: 2,
+                pages: 5,
+                total: 100,
+                offset: 40,
+                query: expect.any(String),
+            });
+
+            // search
+            const { body: searchResponseBody } = await request(app.getHttpServer())
+                .post(`/${PaginationType.OFFSET}/search`)
+                .send({ where: [{ name: { operator: '=', operand: 'same name' } }] })
+                .expect(HttpStatus.OK);
+            const searchDataSet = new Set<number>();
+            for (const data of searchResponseBody.data) {
+                searchDataSet.add(data.id);
+                expect(data.name).toEqual('same name');
+            }
+
+            const { body: searchNextResponseBody } = await request(app.getHttpServer())
+                .post(`/${PaginationType.OFFSET}/search`)
+                .send({ query: searchResponseBody.metadata.query, offset: searchResponseBody.metadata.offset })
+                .expect(HttpStatus.OK);
+            expect(searchNextResponseBody.metadata).toEqual({
+                page: 2,
+                pages: 5,
+                total: 100,
+                offset: 40,
+                query: expect.any(String),
+            });
+
+            for (const data of searchNextResponseBody.data) {
+                expect(data.name).toEqual('same name');
+                expect(searchDataSet.has(data.id)).not.toBeTruthy();
+            }
+
+            const { body: searchNextNextResponseBody } = await request(app.getHttpServer())
+                .post(`/${PaginationType.OFFSET}/search`)
+                .send({ query: searchNextResponseBody.metadata.query, offset: searchNextResponseBody.metadata.offset })
+                .expect(HttpStatus.OK);
+            expect(searchNextNextResponseBody.metadata).toEqual({
+                page: 3,
+                pages: 5,
+                total: 100,
+                offset: 60,
+                query: expect.any(String),
+            });
+            for (const data of searchNextResponseBody.data) {
+                expect(data.name).toEqual('same name');
+                expect(searchDataSet.has(data.id)).not.toBeTruthy();
+            }
         });
 
         it('should be able to set limit only at first request', async () => {
@@ -293,7 +389,7 @@ describe('Pagination', () => {
                 pages: 7,
                 total: 100,
                 offset: limit * 2,
-                query: responseBody.metadata.query,
+                query: expect.any(String),
             });
         });
 
@@ -317,7 +413,7 @@ describe('Pagination', () => {
                 pages: Math.ceil(100 / limit),
                 total: 100,
                 offset: defaultLimit + limit,
-                query: firstResponseBody.metadata.query,
+                query: expect.any(String),
             });
 
             const lastOneOfFirstResponse = firstResponseBody.data.pop();

--- a/spec/pagination/pagination.spec.ts
+++ b/spec/pagination/pagination.spec.ts
@@ -79,13 +79,13 @@ describe('Pagination', () => {
         const { body: nextResponseBody } = await request(app.getHttpServer())
             .get(`/${PaginationType.CURSOR}`)
             .query({
-                query: cursorResponseBody.metadata.nextCursor,
+                nextCursor: cursorResponseBody.metadata.nextCursor,
             })
             .expect(HttpStatus.OK);
         const { body: offsetNextResponseBody } = await request(app.getHttpServer())
             .get(`/${PaginationType.OFFSET}`)
             .query({
-                query: offsetResponseBody.metadata.nextCursor,
+                nextCursor: offsetResponseBody.metadata.nextCursor,
                 offset: offsetResponseBody.metadata.offset,
             })
             .expect(HttpStatus.OK);
@@ -115,7 +115,7 @@ describe('Pagination', () => {
             const { body: nextResponseBody } = await request(app.getHttpServer())
                 .get(`/${PaginationType.CURSOR}`)
                 .query({
-                    query: firstResponseBody.metadata.nextCursor,
+                    nextCursor: firstResponseBody.metadata.nextCursor,
                 })
                 .expect(HttpStatus.OK);
 
@@ -158,7 +158,7 @@ describe('Pagination', () => {
             const { body: nextResponseBody } = await request(app.getHttpServer())
                 .get(`/${PaginationType.CURSOR}`)
                 .query({
-                    query: responseBody.metadata.nextCursor,
+                    nextCursor: responseBody.metadata.nextCursor,
                 })
                 .expect(HttpStatus.OK);
 
@@ -212,7 +212,7 @@ describe('Pagination', () => {
             const { body: nextResponseBody } = await request(app.getHttpServer())
                 .get(`/${PaginationType.OFFSET}`)
                 .query({
-                    query: firstResponseBody.metadata.nextCursor,
+                    nextCursor: firstResponseBody.metadata.nextCursor,
                     offset: firstResponseBody.metadata.offset,
                 })
                 .expect(HttpStatus.OK);
@@ -242,7 +242,7 @@ describe('Pagination', () => {
             const { body: nextResponseBody } = await request(app.getHttpServer())
                 .post(`/${PaginationType.OFFSET}/search`)
                 .send({
-                    query: firstResponseBody.metadata.nextCursor,
+                    nextCursor: firstResponseBody.metadata.nextCursor,
                     offset: firstResponseBody.metadata.offset,
                 })
                 .expect(HttpStatus.OK);
@@ -280,7 +280,7 @@ describe('Pagination', () => {
             const { body: readManyNextResponseBody } = await request(app.getHttpServer())
                 .get(`/${PaginationType.OFFSET}`)
                 .query({
-                    query: readManyResponseBody.metadata.nextCursor,
+                    nextCursor: readManyResponseBody.metadata.nextCursor,
                     offset: readManyResponseBody.metadata.offset,
                 })
                 .expect(HttpStatus.OK);
@@ -313,7 +313,7 @@ describe('Pagination', () => {
 
             const { body: searchNextResponseBody } = await request(app.getHttpServer())
                 .post(`/${PaginationType.OFFSET}/search`)
-                .send({ query: searchResponseBody.metadata.nextCursor, offset: searchResponseBody.metadata.offset })
+                .send({ nextCursor: searchResponseBody.metadata.nextCursor, offset: searchResponseBody.metadata.offset })
                 .expect(HttpStatus.OK);
             expect(searchNextResponseBody.metadata).toEqual({
                 page: 2,
@@ -330,7 +330,7 @@ describe('Pagination', () => {
 
             const { body: searchNextNextResponseBody } = await request(app.getHttpServer())
                 .post(`/${PaginationType.OFFSET}/search`)
-                .send({ query: searchNextResponseBody.metadata.nextCursor, offset: searchNextResponseBody.metadata.offset })
+                .send({ nextCursor: searchNextResponseBody.metadata.nextCursor, offset: searchNextResponseBody.metadata.offset })
                 .expect(HttpStatus.OK);
             expect(searchNextNextResponseBody.metadata).toEqual({
                 page: 3,
@@ -357,7 +357,7 @@ describe('Pagination', () => {
             const { body: nextResponseBody } = await request(app.getHttpServer())
                 .get(`/${PaginationType.OFFSET}`)
                 .query({
-                    query: responseBody.metadata.nextCursor,
+                    nextCursor: responseBody.metadata.nextCursor,
                     offset: responseBody.metadata.offset,
                     limit,
                 })
@@ -378,7 +378,7 @@ describe('Pagination', () => {
             const { body: nextResponseBody } = await request(app.getHttpServer())
                 .get(`/${PaginationType.OFFSET}`)
                 .query({
-                    query: firstResponseBody.metadata.nextCursor,
+                    nextCursor: firstResponseBody.metadata.nextCursor,
                     offset: firstResponseBody.metadata.offset,
                     limit,
                 })

--- a/spec/param-option/param-option.entity-key.spec.ts
+++ b/spec/param-option/param-option.entity-key.spec.ts
@@ -1,16 +1,15 @@
 import { HttpStatus, INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import _ from 'lodash';
 import request from 'supertest';
 
 import { DynamicCrudModule } from '../dynamic-crud.module';
 import { TestHelper } from '../test.helper';
 
-describe('Params Option - entity의 key를 params으로 사용하는 경우', () => {
+describe('Params Option - When using the entity`s key as params', () => {
     let app: INestApplication;
     const param = 'name';
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [
                 DynamicCrudModule({
@@ -26,7 +25,7 @@ describe('Params Option - entity의 key를 params으로 사용하는 경우', ()
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });
@@ -45,7 +44,7 @@ describe('Params Option - entity의 key를 params으로 사용하는 경우', ()
         const names = ['name1', 'name1', 'name2', 'name2', 'name3', 'name1'];
 
         await Promise.all(
-            _.range(0, names.length).map((index) =>
+            Array.from({ length: names.length }, (_, index) => index).map((index) =>
                 request(app.getHttpServer()).post('/base').send({ name: names[index] }).expect(HttpStatus.CREATED),
             ),
         );

--- a/spec/param-option/param-option.non-entity-key.spec.ts
+++ b/spec/param-option/param-option.non-entity-key.spec.ts
@@ -1,6 +1,5 @@
 import { HttpStatus, INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import _ from 'lodash';
 import request from 'supertest';
 
 import { DynamicCrudModule } from '../dynamic-crud.module';
@@ -10,7 +9,7 @@ describe('Params Option - used as params instead of key of entity', () => {
     let app: INestApplication;
     const param = 'unknownProperty';
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [
                 DynamicCrudModule({
@@ -26,7 +25,7 @@ describe('Params Option - used as params instead of key of entity', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });
@@ -45,7 +44,7 @@ describe('Params Option - used as params instead of key of entity', () => {
         const names = ['name1', 'name1', 'name2', 'name2', 'name3', 'name1'];
 
         await Promise.all(
-            _.range(0, names.length).map((index) =>
+            Array.from({ length: names.length }, (_, index) => index).map((index) =>
                 request(app.getHttpServer()).post('/base').send({ name: names[index] }).expect(HttpStatus.CREATED),
             ),
         );

--- a/spec/param-option/param-option.with-interceptor.spec.ts
+++ b/spec/param-option/param-option.with-interceptor.spec.ts
@@ -1,6 +1,5 @@
 import { HttpStatus, INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import _ from 'lodash';
 import request from 'supertest';
 
 import { ParamsInterceptor } from './params.interceptor';
@@ -11,7 +10,7 @@ describe('Params Option - changing params to Interceptor', () => {
     let app: INestApplication;
     const param = 'custom';
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [
                 DynamicCrudModule({
@@ -27,7 +26,7 @@ describe('Params Option - changing params to Interceptor', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });
@@ -46,7 +45,7 @@ describe('Params Option - changing params to Interceptor', () => {
         const names = ['name1', 'name1', 'name2', 'name2', 'name3', 'name1'];
 
         await Promise.all(
-            _.range(0, names.length).map((index) =>
+            Array.from({ length: names.length }, (_, index) => index).map((index) =>
                 request(app.getHttpServer()).post('/base').send({ name: names[index] }).expect(HttpStatus.CREATED),
             ),
         );

--- a/spec/pgsql/pgsql.spec.ts
+++ b/spec/pgsql/pgsql.spec.ts
@@ -59,7 +59,7 @@ class TestModule {}
 describe('Search complex conditions', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [TestModule, TestHelper.getTypeOrmPgsqlModule([TestEntity])],
         }).compile();
@@ -79,7 +79,7 @@ describe('Search complex conditions', () => {
         );
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/read-many/read-many.controller.spec.ts
+++ b/spec/read-many/read-many.controller.spec.ts
@@ -55,7 +55,7 @@ describe('ReadMany - Options', () => {
         it('should return next 20 entities after cursor in ascending order', async () => {
             const firstResponse = await request(app.getHttpServer()).get('/sort-asc').expect(HttpStatus.OK);
             const nextResponse = await request(app.getHttpServer()).get('/sort-asc').query({
-                query: firstResponse.body.metadata.nextCursor,
+                nextCursor: firstResponse.body.metadata.nextCursor,
             });
 
             expect(nextResponse.statusCode).toEqual(HttpStatus.OK);
@@ -100,13 +100,13 @@ describe('ReadMany - Options', () => {
             const { body: nextResponse } = await request(app.getHttpServer())
                 .get('/sort-desc')
                 .query({
-                    query: firstResponse.metadata.nextCursor,
+                    nextCursor: firstResponse.metadata.nextCursor,
                 })
                 .expect(HttpStatus.OK);
             const { body: secondNextResponse } = await request(app.getHttpServer())
                 .get('/sort-desc')
                 .query({
-                    query: nextResponse.metadata.nextCursor,
+                    nextCursor: nextResponse.metadata.nextCursor,
                 })
                 .expect(HttpStatus.OK);
 

--- a/spec/read-many/read-many.controller.spec.ts
+++ b/spec/read-many/read-many.controller.spec.ts
@@ -55,7 +55,7 @@ describe('ReadMany - Options', () => {
         it('should return next 20 entities after cursor in ascending order', async () => {
             const firstResponse = await request(app.getHttpServer()).get('/sort-asc').expect(HttpStatus.OK);
             const nextResponse = await request(app.getHttpServer()).get('/sort-asc').query({
-                nextCursor: firstResponse.body.metadata.nextCursor,
+                query: firstResponse.body.metadata.query,
             });
 
             expect(nextResponse.statusCode).toEqual(HttpStatus.OK);
@@ -100,13 +100,13 @@ describe('ReadMany - Options', () => {
             const { body: nextResponse } = await request(app.getHttpServer())
                 .get('/sort-desc')
                 .query({
-                    nextCursor: firstResponse.metadata.nextCursor,
+                    query: firstResponse.metadata.query,
                 })
                 .expect(HttpStatus.OK);
             const { body: secondNextResponse } = await request(app.getHttpServer())
                 .get('/sort-desc')
                 .query({
-                    nextCursor: nextResponse.metadata.nextCursor,
+                    query: nextResponse.metadata.query,
                 })
                 .expect(HttpStatus.OK);
 

--- a/spec/read-many/read-many.controller.spec.ts
+++ b/spec/read-many/read-many.controller.spec.ts
@@ -55,7 +55,7 @@ describe('ReadMany - Options', () => {
         it('should return next 20 entities after cursor in ascending order', async () => {
             const firstResponse = await request(app.getHttpServer()).get('/sort-asc').expect(HttpStatus.OK);
             const nextResponse = await request(app.getHttpServer()).get('/sort-asc').query({
-                query: firstResponse.body.metadata.query,
+                query: firstResponse.body.metadata.nextCursor,
             });
 
             expect(nextResponse.statusCode).toEqual(HttpStatus.OK);
@@ -100,23 +100,19 @@ describe('ReadMany - Options', () => {
             const { body: nextResponse } = await request(app.getHttpServer())
                 .get('/sort-desc')
                 .query({
-                    query: firstResponse.metadata.query,
+                    query: firstResponse.metadata.nextCursor,
                 })
                 .expect(HttpStatus.OK);
             const { body: secondNextResponse } = await request(app.getHttpServer())
                 .get('/sort-desc')
                 .query({
-                    query: nextResponse.metadata.query,
+                    query: nextResponse.metadata.nextCursor,
                 })
                 .expect(HttpStatus.OK);
 
-            expect(nextResponse.metadata.query).toEqual(expect.any(String));
-            expect(nextResponse.metadata.query).not.toEqual(firstResponse.metadata.query);
-            expect(secondNextResponse.metadata.query).toEqual(expect.any(String));
-            expect(secondNextResponse.metadata.query).not.toEqual(firstResponse.metadata.query);
-
             expect(nextResponse.metadata.nextCursor).not.toEqual(firstResponse.metadata.nextCursor);
-            expect(secondNextResponse.metadata.nextCursor).not.toEqual(nextResponse.metadata.nextCursor);
+            expect(secondNextResponse.metadata.nextCursor).toEqual(expect.any(String));
+            expect(secondNextResponse.metadata.nextCursor).not.toEqual(firstResponse.metadata.nextCursor);
 
             expect(nextResponse.metadata.total).toEqual(firstResponse.metadata.total - nextResponse.metadata.limit);
             expect(secondNextResponse.metadata.total).toEqual(nextResponse.metadata.total - secondNextResponse.metadata.limit);

--- a/spec/relation-entities/README.ko.md
+++ b/spec/relation-entities/README.ko.md
@@ -1,0 +1,13 @@
+### Relation Test Case
+
+There are the fours entities
+
+-   writerEntity: Manages writer information.
+-   categoryEntity: Manages the category of the question.
+-   questionEntity: Manages a question.
+-   CommentEntity: Manages comments added to a question.
+
+Entities are related as follows.
+
+questionEntity --ManyToOne-- writerEntity, categoryEntity
+<br/>&nbsp;&nbsp;ㄴOneToMany- CommentEntity --ManyToOne-- writerEntity

--- a/spec/relation-entities/README.ko.md
+++ b/spec/relation-entities/README.ko.md
@@ -1,13 +1,13 @@
 ### Relation Test Case
 
-There are the fours entities
+다음의 Entity가 있습니다.
 
--   writerEntity: Manages writer information.
--   categoryEntity: Manages the category of the question.
--   questionEntity: Manages a question.
--   CommentEntity: Manages comments added to a question.
+-   writerEntity: 작성자 정보를 관리합니다.
+-   categoryEntity: 질문글의 종류를 관리합니다.
+-   questionEntity: 질문글을 관리합니다.
+-   CommentEntity: 질문글에 추가되는 댓글을 관리합니다.
 
-Entities are related as follows.
+Entity는 아래와 같이 관계되어있습니다.
 
 questionEntity --ManyToOne-- writerEntity, categoryEntity
 <br/>&nbsp;&nbsp;ㄴOneToMany- CommentEntity --ManyToOne-- writerEntity

--- a/spec/relation-entities/README.md
+++ b/spec/relation-entities/README.md
@@ -1,13 +1,13 @@
 ### Relation Test Case
 
-다음의 Entity가 있습니다.
+There are the fours entities
 
--   writerEntity: 작성자 정보를 관리합니다.
--   categoryEntity: 질문글의 종류를 관리합니다.
--   questionEntity: 질문글을 관리합니다.
--   CommentEntity: 질문글에 추가되는 댓글을 관리합니다.
+-   writerEntity: Manages writer information.
+-   categoryEntity: Manages the category of the question.
+-   questionEntity: Manages a question.
+-   CommentEntity: Manages comments added to a question.
 
-Entity는 아래와 같이 관계되어있습니다.
+Entities are related as follows.
 
 questionEntity --ManyToOne-- writerEntity, categoryEntity
 <br/>&nbsp;&nbsp;ㄴOneToMany- CommentEntity --ManyToOne-- writerEntity

--- a/spec/relation-entities/relation-entities-disable-relations.spec.ts
+++ b/spec/relation-entities/relation-entities-disable-relations.spec.ts
@@ -8,7 +8,7 @@ import { TestHelper } from '../test.helper';
 describe('disable relation option', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [
                 RelationEntitiesModule({
@@ -30,7 +30,7 @@ describe('disable relation option', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/relation-entities/relation-entities-interceptor.spec.ts
+++ b/spec/relation-entities/relation-entities-interceptor.spec.ts
@@ -9,7 +9,7 @@ import { TestHelper } from '../test.helper';
 describe('relation interceptor', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [
                 RelationEntitiesModule({
@@ -28,7 +28,7 @@ describe('relation interceptor', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/relation-entities/relation-entities-read.spec.ts
+++ b/spec/relation-entities/relation-entities-read.spec.ts
@@ -8,7 +8,7 @@ import { TestHelper } from '../test.helper';
 describe('Relation Entities Read', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [
                 RelationEntitiesModule({
@@ -25,7 +25,7 @@ describe('Relation Entities Read', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/relation-entities/relation-entities-read.spec.ts
+++ b/spec/relation-entities/relation-entities-read.spec.ts
@@ -190,7 +190,7 @@ describe('Relation Entities Read', () => {
 
         const { body: commentListBodyNext } = await request(app.getHttpServer())
             .get('/comment')
-            .query({ nextCursor: commentListBody.metadata.nextCursor })
+            .query({ query: commentListBody.metadata.query })
             .expect(HttpStatus.OK);
 
         expect(commentListBodyNext.data).toHaveLength(1);

--- a/spec/relation-entities/relation-entities-read.spec.ts
+++ b/spec/relation-entities/relation-entities-read.spec.ts
@@ -190,7 +190,7 @@ describe('Relation Entities Read', () => {
 
         const { body: commentListBodyNext } = await request(app.getHttpServer())
             .get('/comment')
-            .query({ query: commentListBody.metadata.query })
+            .query({ nextCursor: commentListBody.metadata.query })
             .expect(HttpStatus.OK);
 
         expect(commentListBodyNext.data).toHaveLength(1);

--- a/spec/relation-entities/relation-entities-search.spec.ts
+++ b/spec/relation-entities/relation-entities-search.spec.ts
@@ -8,7 +8,7 @@ import { TestHelper } from '../test.helper';
 describe('Relation Entities Search', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [
                 RelationEntitiesModule({
@@ -23,7 +23,7 @@ describe('Relation Entities Search', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/relation-entities/relation-entities-seleted-relations.spec.ts
+++ b/spec/relation-entities/relation-entities-seleted-relations.spec.ts
@@ -8,7 +8,7 @@ import { TestHelper } from '../test.helper';
 describe('disable relation option', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [
                 RelationEntitiesModule({
@@ -31,7 +31,7 @@ describe('disable relation option', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/relation-entities/relation-entities.spec.ts
+++ b/spec/relation-entities/relation-entities.spec.ts
@@ -7,7 +7,7 @@ import { TestHelper } from '../test.helper';
 describe('Relation Entities Routes', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [
                 RelationEntitiesModule({
@@ -22,7 +22,7 @@ describe('Relation Entities Routes', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/request-interceptor/request-interceptor.spec.ts
+++ b/spec/request-interceptor/request-interceptor.spec.ts
@@ -11,7 +11,7 @@ describe('Request Interceptor', () => {
     let app: INestApplication;
     let service: BaseService;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [RequestInterceptorModule, TestHelper.getTypeOrmMysqlModule([BaseEntity])],
         }).compile();
@@ -23,7 +23,7 @@ describe('Request Interceptor', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/response-interceptor/response-interceptor.spec.ts
+++ b/spec/response-interceptor/response-interceptor.spec.ts
@@ -11,7 +11,7 @@ describe('Response Interceptor', () => {
     let app: INestApplication;
     let service: BaseService;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [BaseModule, TestHelper.getTypeOrmMysqlModule([BaseEntity])],
         }).compile();
@@ -23,7 +23,7 @@ describe('Response Interceptor', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/search-json-column/json.module.ts
+++ b/spec/search-json-column/json.module.ts
@@ -1,10 +1,11 @@
 /* eslint-disable max-classes-per-file */
 import { Controller, Injectable, Module } from '@nestjs/common';
 import { InjectRepository, TypeOrmModule } from '@nestjs/typeorm';
+import { IsOptional } from 'class-validator';
 import { BaseEntity, Column, Entity, PrimaryGeneratedColumn, Repository } from 'typeorm';
 
 import { Address, Person } from './interface';
-import { Crud, CrudService, CrudController } from '../../src';
+import { Crud, CrudService, CrudController, GROUP } from '../../src';
 
 @Entity('json_column_entity')
 export class JsonColumnEntity extends BaseEntity {
@@ -15,9 +16,11 @@ export class JsonColumnEntity extends BaseEntity {
     colors: string[];
 
     @Column({ type: 'json', nullable: true })
+    @IsOptional({ groups: [GROUP.SEARCH] })
     friends: Person[];
 
     @Column({ type: 'json' })
+    @IsOptional({ groups: [GROUP.SEARCH] })
     address: Address;
 }
 

--- a/spec/search-json-column/jsonb.module.ts
+++ b/spec/search-json-column/jsonb.module.ts
@@ -1,10 +1,11 @@
 /* eslint-disable max-classes-per-file */
 import { Controller, Injectable, Module } from '@nestjs/common';
 import { InjectRepository, TypeOrmModule } from '@nestjs/typeorm';
+import { IsOptional } from 'class-validator';
 import { BaseEntity, Column, Entity, PrimaryGeneratedColumn, Repository } from 'typeorm';
 
 import { Address, Person } from './interface';
-import { Crud, CrudService, CrudController } from '../../src';
+import { Crud, CrudService, CrudController, GROUP } from '../../src';
 
 @Entity('jsonb_column_entity')
 export class JsonbColumnEntity extends BaseEntity {
@@ -12,12 +13,15 @@ export class JsonbColumnEntity extends BaseEntity {
     id: number;
 
     @Column({ type: 'jsonb' })
+    @IsOptional({ groups: [GROUP.SEARCH] })
     colors: string[];
 
     @Column({ type: 'jsonb', nullable: true })
+    @IsOptional({ groups: [GROUP.SEARCH] })
     friends: Person[];
 
     @Column({ type: 'json' })
+    @IsOptional({ groups: [GROUP.SEARCH] })
     address: Address;
 }
 

--- a/spec/search/module.ts
+++ b/spec/search/module.ts
@@ -39,6 +39,7 @@ export class TestService extends CrudService<TestEntity> {
             limitOfTake: 100,
         },
     },
+    logging: true,
 })
 @Controller('base')
 export class TestController implements CrudController<TestEntity> {

--- a/spec/search/search-complex-condition.spec.ts
+++ b/spec/search/search-complex-condition.spec.ts
@@ -4,7 +4,6 @@ import { Controller, Injectable, Module } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { InjectRepository, TypeOrmModule } from '@nestjs/typeorm';
 import { IsOptional } from 'class-validator';
-import _ from 'lodash';
 import request from 'supertest';
 import { Entity, BaseEntity, Repository, PrimaryColumn, Column, ObjectLiteral } from 'typeorm';
 
@@ -51,7 +50,7 @@ class TestModule {}
 describe('Search complex conditions', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [TestModule, TestHelper.getTypeOrmPgsqlModule([TestEntity])],
         }).compile();
@@ -59,7 +58,7 @@ describe('Search complex conditions', () => {
         await app.init();
 
         await Promise.all(
-            _.range(10).map((no) =>
+            Array.from({ length: 10 }, (_, index) => index).map((no) =>
                 request(app.getHttpServer())
                     .post('/base')
                     .send({
@@ -71,7 +70,7 @@ describe('Search complex conditions', () => {
         );
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/search/search-cursor-pagination.spec.ts
+++ b/spec/search/search-cursor-pagination.spec.ts
@@ -228,4 +228,14 @@ describe('Search Cursor Pagination', () => {
             },
         });
     });
+
+    it('should be use empty body', async () => {
+        const { body } = await request(app.getHttpServer()).post('/base/search').send({}).expect(HttpStatus.OK);
+        expect(body.data).toBeDefined();
+        expect(body.metadata).toBeDefined();
+
+        const { body: emptyWhere } = await request(app.getHttpServer()).post('/base/search').send({ where: [] }).expect(HttpStatus.OK);
+        expect(emptyWhere.data).toBeDefined();
+        expect(emptyWhere.metadata).toBeDefined();
+    });
 });

--- a/spec/search/search-cursor-pagination.spec.ts
+++ b/spec/search/search-cursor-pagination.spec.ts
@@ -67,14 +67,14 @@ describe('Search Cursor Pagination', () => {
             .expect(HttpStatus.OK);
         expect(firstResponse.data).toHaveLength(10);
 
-        const lastEntity = PaginationHelper.deserialize<TestEntity>(firstResponse.metadata.nextCursor);
-        expect(lastEntity).toEqual({ col1: 'col1_29' });
-        const preCondition: Record<string, unknown> = PaginationHelper.deserialize(firstResponse.metadata.query);
+        const preCondition: Record<string, unknown> = PaginationHelper.deserialize(firstResponse.metadata.nextCursor);
         expect(preCondition).toEqual({
             where: expect.any(String),
             nextCursor: expect.any(String),
             total: expect.any(Number),
         });
+        const lastEntity = PaginationHelper.deserialize<TestEntity>(preCondition.nextCursor as string);
+        expect(lastEntity).toEqual({ col1: 'col1_29' });
         expect(PaginationHelper.deserialize(preCondition.where as string)).toEqual({
             where: [
                 {
@@ -88,7 +88,7 @@ describe('Search Cursor Pagination', () => {
 
         const { body: secondResponse } = await request(app.getHttpServer())
             .post('/base/search')
-            .send({ nextCursor: firstResponse.metadata.nextCursor, query: firstResponse.metadata.query })
+            .send({ query: firstResponse.metadata.nextCursor })
             .expect(HttpStatus.OK);
 
         expect(secondResponse.data).toHaveLength(10);
@@ -98,15 +98,14 @@ describe('Search Cursor Pagination', () => {
             expect(firstDataCol1.has(nextData.col1)).not.toBeTruthy();
         }
 
-        const nextLastEntity = PaginationHelper.deserialize(secondResponse.metadata.nextCursor);
-        expect(nextLastEntity).toEqual({ col1: 'col1_1' });
-
-        const nextPreCondition: Record<string, unknown> = PaginationHelper.deserialize(secondResponse.metadata.query);
+        const nextPreCondition: Record<string, unknown> = PaginationHelper.deserialize(secondResponse.metadata.nextCursor);
         expect(nextPreCondition).toEqual({
             where: expect.any(String),
             nextCursor: expect.any(String),
             total: expect.any(Number),
         });
+        const nextLastEntity = PaginationHelper.deserialize(nextPreCondition.nextCursor as string);
+        expect(nextLastEntity).toEqual({ col1: 'col1_1' });
         expect(PaginationHelper.deserialize(nextPreCondition.where as string)).toEqual({
             ...searchRequestBody,
             withDeleted: false,

--- a/spec/search/search-cursor-pagination.spec.ts
+++ b/spec/search/search-cursor-pagination.spec.ts
@@ -88,7 +88,7 @@ describe('Search Cursor Pagination', () => {
 
         const { body: secondResponse } = await request(app.getHttpServer())
             .post('/base/search')
-            .send({ query: firstResponse.metadata.nextCursor })
+            .send({ nextCursor: firstResponse.metadata.nextCursor })
             .expect(HttpStatus.OK);
 
         expect(secondResponse.data).toHaveLength(10);

--- a/spec/search/search-query-operator.spec.ts
+++ b/spec/search/search-query-operator.spec.ts
@@ -1,8 +1,6 @@
-/* eslint-disable @typescript-eslint/quotes */
-/* eslint-disable no-useless-escape */
-import { INestApplication } from '@nestjs/common';
+import { HttpStatus, INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import _ from 'lodash';
+import request from 'supertest';
 
 import { TestEntity, TestModule, TestService } from './module';
 import { RequestSearchDto } from '../../src/lib/dto/request-search.dto';
@@ -10,14 +8,13 @@ import { TestHelper } from '../test.helper';
 
 describe('Search Query Operator', () => {
     let app: INestApplication;
-    let service: TestService;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [TestModule, TestHelper.getTypeOrmMysqlModule([TestEntity])],
         }).compile();
         app = moduleFixture.createNestApplication();
-        service = moduleFixture.get<TestService>(TestService);
+        const service: TestService = moduleFixture.get<TestService>(TestService);
 
         /**
          * 10 entities are created for the test.
@@ -35,14 +32,14 @@ describe('Search Query Operator', () => {
          * - when index is [5-9], is has null
          */
         await Promise.all(
-            _.range(5).map((no: number) =>
+            Array.from({ length: 5 }, (_, index) => index).map((no: number) =>
                 service.repository.save(
                     service.repository.create({ col1: `col${no % 2 === 0 ? '0' : '1'}_${no}`, col2: no, col3: 10 - no }),
                 ),
             ),
         );
         await Promise.all(
-            _.range(5, 10).map((no: number) =>
+            Array.from({ length: 5 }, (_, index) => index + 5).map((no: number) =>
                 service.repository.save(service.repository.create({ col1: `col${no % 2 === 0 ? '0' : '1'}_${no}`, col2: no })),
             ),
         );
@@ -50,7 +47,7 @@ describe('Search Query Operator', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });
@@ -63,10 +60,9 @@ describe('Search Query Operator', () => {
         ];
 
         for (const requestSearchDto of requestSearchDtoList) {
-            const { data, metadata } = await service.reservedSearch({
-                requestSearchDto,
-                relations: [],
-            });
+            const {
+                body: { data, metadata },
+            } = await request(app.getHttpServer()).post('/base/search').send(requestSearchDto).expect(HttpStatus.OK);
             expect(data).toHaveLength(5);
             expect(Object.keys(data[0])).toEqual(expect.arrayContaining(requestSearchDto.select as unknown[]));
 
@@ -77,6 +73,7 @@ describe('Search Query Operator', () => {
     });
 
     it('should query condition with RequestSearchDto when `where` is provided', async () => {
+        const take = 100;
         const fixtures: Array<[RequestSearchDto<TestEntity>, number[]]> = [
             [{ where: [{ col2: { operator: '=', operand: 5 } }] }, [5]],
             [{ where: [{ col2: { operator: '=', operand: 5, not: true } }] }, [0, 1, 2, 3, 4, 6, 7, 8, 9]],
@@ -112,8 +109,13 @@ describe('Search Query Operator', () => {
             [{ where: [{ col3: { operator: 'NULL', not: true } }] }, [0, 1, 2, 3, 4]],
         ];
         for (const [requestSearchDto, expected] of fixtures) {
-            const { data, metadata } = await service.reservedSearch({ requestSearchDto, relations: [] });
-            const col2Values = data.map((d) => d.col2);
+            const {
+                body: { data, metadata },
+            } = await request(app.getHttpServer())
+                .post('/base/search')
+                .send({ ...requestSearchDto, take })
+                .expect(HttpStatus.OK);
+            const col2Values = (data as TestEntity[]).map((d) => d.col2);
             expect(col2Values).toHaveLength(expected.length);
             expect(col2Values).toEqual(expect.arrayContaining(expected));
 
@@ -123,6 +125,7 @@ describe('Search Query Operator', () => {
     });
 
     it('nested complex where condition test', async () => {
+        const take = 100;
         const fixtures: Array<[RequestSearchDto<TestEntity>, number[]]> = [
             [{ where: [{ col2: { operator: 'BETWEEN', operand: [3, 5] } }], order: { col1: 'ASC' } }, [3, 4, 5]],
             [
@@ -167,8 +170,13 @@ describe('Search Query Operator', () => {
             ],
         ];
         for (const [requestSearchDto, expected] of fixtures) {
-            const { data, metadata } = await service.reservedSearch({ requestSearchDto, relations: [] });
-            const col2Values = data.map((d) => d.col2);
+            const {
+                body: { data, metadata },
+            } = await request(app.getHttpServer())
+                .post('/base/search')
+                .send({ ...requestSearchDto, take })
+                .expect(HttpStatus.OK);
+            const col2Values = (data as TestEntity[]).map((d) => d.col2);
             expect(col2Values).toHaveLength(expected.length);
             expect(col2Values).toEqual(expect.arrayContaining(expected));
 

--- a/spec/search/search-query-operator.spec.ts
+++ b/spec/search/search-query-operator.spec.ts
@@ -67,7 +67,6 @@ describe('Search Query Operator', () => {
             expect(Object.keys(data[0])).toEqual(expect.arrayContaining(requestSearchDto.select as unknown[]));
 
             expect(metadata.nextCursor).toBeDefined();
-            expect(metadata.query).toBeDefined();
             expect(metadata.total).toEqual(10);
         }
     });
@@ -120,7 +119,6 @@ describe('Search Query Operator', () => {
             expect(col2Values).toEqual(expect.arrayContaining(expected));
 
             expect(metadata.nextCursor).toBeDefined();
-            expect(metadata.query).toBeDefined();
         }
     });
 
@@ -181,7 +179,6 @@ describe('Search Query Operator', () => {
             expect(col2Values).toEqual(expect.arrayContaining(expected));
 
             expect(metadata.nextCursor).toBeDefined();
-            expect(metadata.query).toBeDefined();
         }
     });
 });

--- a/spec/soft-delete-and-recover/soft-delete-and-recover.controller.spec.ts
+++ b/spec/soft-delete-and-recover/soft-delete-and-recover.controller.spec.ts
@@ -9,7 +9,7 @@ import { TestHelper } from '../test.helper';
 describe('Soft-delete and recover test', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [SoftDeleteAndRecoverModule, TestHelper.getTypeOrmMysqlModule([BaseEntity])],
         }).compile();
@@ -18,7 +18,11 @@ describe('Soft-delete and recover test', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    beforeEach(async () => {
+        await BaseEntity.delete({});
+    });
+
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/sub-path/sub-path-more-than-one-parent.spec.ts
+++ b/spec/sub-path/sub-path-more-than-one-parent.spec.ts
@@ -1,6 +1,5 @@
 import { INestApplication, HttpStatus } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import _ from 'lodash';
 import request from 'supertest';
 
 import { SubPathModule } from './sub-path.module';
@@ -9,7 +8,7 @@ import { TestHelper } from '../test.helper';
 describe('Subpath - more then one parent parameter', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [SubPathModule()],
         }).compile();
@@ -25,7 +24,7 @@ describe('Subpath - more then one parent parameter', () => {
          * | parent1  | 1     | writer5, 7, 9 |
          */
         await Promise.all(
-            _.range(0, 10).map((parentNo) =>
+            Array.from({ length: 10 }, (_, index) => index).map((parentNo) =>
                 request(app.getHttpServer())
                     .post(`/parent${parentNo % 2 === 0 ? '0' : '1'}/sub/${parentNo < 5 ? 0 : 1}/child`)
                     .send({ name: `writer${parentNo}` })
@@ -34,7 +33,7 @@ describe('Subpath - more then one parent parameter', () => {
         );
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });
@@ -89,7 +88,7 @@ describe('Subpath - more then one parent parameter', () => {
     });
 
     it('should meet conditions of parent params - search', async () => {
-        const operand = _.range(0, 10).map((parentNo) => `writer${parentNo}`);
+        const operand = Array.from({ length: 10 }, (_, index) => index).map((parentNo) => `writer${parentNo}`);
         for (const parentName of ['parent0', 'parent1']) {
             for (const subId of [0, 1]) {
                 const { body } = await request(app.getHttpServer())

--- a/spec/sub-path/sub-path-one-parent.spec.ts
+++ b/spec/sub-path/sub-path-one-parent.spec.ts
@@ -1,23 +1,26 @@
 import { INestApplication, HttpStatus } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import _ from 'lodash';
 import request from 'supertest';
 
+import { DepthOneEntity } from './depth-one.entity';
 import { SubPathModule } from './sub-path.module';
 import { TestHelper } from '../test.helper';
 
 describe('Subpath - one parent parameter', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [SubPathModule()],
         }).compile();
         app = moduleFixture.createNestApplication();
         await app.init();
+    });
 
+    beforeEach(async () => {
+        await DepthOneEntity.delete({});
         await Promise.all(
-            _.range(0, 5).map((parentNo) =>
+            Array.from({ length: 5 }, (_, index) => index).map((parentNo) =>
                 request(app.getHttpServer())
                     .post(`/parent${parentNo % 2 === 0 ? '0' : '1'}/child`)
                     .send({ name: `writer${parentNo}` })
@@ -26,7 +29,7 @@ describe('Subpath - one parent parameter', () => {
         );
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });
@@ -65,7 +68,7 @@ describe('Subpath - one parent parameter', () => {
     });
 
     it('should meet conditions of parent params - search', async () => {
-        const operand = _.range(0, 5).map((parentNo) => `writer${parentNo}`);
+        const operand = Array.from({ length: 5 }, (_, index) => index).map((parentNo) => `writer${parentNo}`);
         const { body } = await request(app.getHttpServer())
             .post('/parent0/child/search')
             .send({

--- a/spec/sub-path/sub-path.spec.ts
+++ b/spec/sub-path/sub-path.spec.ts
@@ -1,6 +1,5 @@
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import _ from 'lodash';
 
 import { SubPathModule } from './sub-path.module';
 import { TestHelper } from '../test.helper';
@@ -8,7 +7,7 @@ import { TestHelper } from '../test.helper';
 describe('Subpath', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [SubPathModule()],
         }).compile();
@@ -16,7 +15,7 @@ describe('Subpath', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/swagger-decorator/swagger-decorator.spec.ts
+++ b/spec/swagger-decorator/swagger-decorator.spec.ts
@@ -9,7 +9,7 @@ import { TestHelper } from '../test.helper';
 describe('SwaggerDecorator', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [SwaggerDecoratorModule, TestHelper.getTypeOrmMysqlModule([BaseEntity])],
         }).compile();
@@ -19,7 +19,7 @@ describe('SwaggerDecorator', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/test.helper.ts
+++ b/spec/test.helper.ts
@@ -88,7 +88,7 @@ export class TestHelper {
             if (!route.root?.operationId) {
                 return summary;
             }
-            summary[route.root.operationId] = route;
+            summary[`${route.root.method} ${route.root.path}`] = route;
             return summary;
         }, {} as Record<string, DenormalizedDoc>);
     }

--- a/spec/unique-key/unique.controller.create.mysql.spec.ts
+++ b/spec/unique-key/unique.controller.create.mysql.spec.ts
@@ -9,7 +9,7 @@ import { TestHelper } from '../test.helper';
 describe('UniqueController', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [UniqueModule, TestHelper.getTypeOrmMysqlModule([UniqueEntity])],
         }).compile();
@@ -18,7 +18,7 @@ describe('UniqueController', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/unique-key/unique.controller.create.pgsql.spec.ts
+++ b/spec/unique-key/unique.controller.create.pgsql.spec.ts
@@ -9,7 +9,7 @@ import { TestHelper } from '../test.helper';
 describe('UniqueController', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [UniqueModule, TestHelper.getTypeOrmPgsqlModule([UniqueEntity])],
         }).compile();
@@ -18,7 +18,7 @@ describe('UniqueController', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/spec/unique-key/unique.controller.create.spec.ts
+++ b/spec/unique-key/unique.controller.create.spec.ts
@@ -9,7 +9,7 @@ import { TestHelper } from '../test.helper';
 describe('UniqueController', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [UniqueModule, TestHelper.getTypeOrmMysqlModule([UniqueEntity])],
         }).compile();
@@ -18,7 +18,7 @@ describe('UniqueController', () => {
         await app.init();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await TestHelper.dropTypeOrmEntityTables();
         await app?.close();
     });

--- a/src/lib/abstract/abstract.pagination-request.ts
+++ b/src/lib/abstract/abstract.pagination-request.ts
@@ -1,0 +1,60 @@
+import { PaginationType } from '../interface';
+
+interface PaginationQuery {
+    where: string;
+    nextCursor: string;
+    total: number;
+}
+const encoding = 'base64';
+
+export abstract class AbstractPaginationRequest {
+    private _isNext: boolean = false;
+    private _where: string;
+    private _total: number;
+
+    type: PaginationType;
+
+    setWhere(where: string | undefined) {
+        if (!where) {
+            return;
+        }
+        this._where = where;
+    }
+
+    makeQuery(total: number, nextCursor: string): string {
+        return Buffer.from(
+            JSON.stringify({
+                where: this._where,
+                nextCursor,
+                total,
+            }),
+        ).toString(encoding);
+    }
+
+    setQuery(query: string) {
+        try {
+            const paginationType: PaginationQuery = JSON.parse(Buffer.from(query, encoding).toString());
+            this._where = paginationType.where;
+            this._total = paginationType.total;
+            // this._nextCursor = paginationType.nextCursor;
+
+            this._isNext = true;
+        } catch {
+            return {} as PaginationQuery;
+        }
+    }
+
+    protected get total() {
+        return this._total;
+    }
+
+    get where() {
+        return this._where;
+    }
+
+    get isNext() {
+        return this._isNext && this.total != null;
+    }
+
+    abstract nextTotal(dataLength?: number): number;
+}

--- a/src/lib/abstract/abstract.pagination-request.ts
+++ b/src/lib/abstract/abstract.pagination-request.ts
@@ -11,6 +11,7 @@ export abstract class AbstractPaginationRequest {
     private _isNext: boolean = false;
     private _where: string;
     private _total: number;
+    private _nextCursor: string;
 
     type: PaginationType;
 
@@ -36,7 +37,7 @@ export abstract class AbstractPaginationRequest {
             const paginationType: PaginationQuery = JSON.parse(Buffer.from(query, encoding).toString());
             this._where = paginationType.where;
             this._total = paginationType.total;
-            // this._nextCursor = paginationType.nextCursor;
+            this._nextCursor = paginationType.nextCursor;
 
             this._isNext = true;
         } catch {
@@ -54,6 +55,10 @@ export abstract class AbstractPaginationRequest {
 
     get isNext() {
         return this._isNext && this.total != null;
+    }
+
+    get nextCursor() {
+        return this._nextCursor;
     }
 
     abstract nextTotal(dataLength?: number): number;

--- a/src/lib/abstract/abstract.pagination-request.ts
+++ b/src/lib/abstract/abstract.pagination-request.ts
@@ -1,3 +1,6 @@
+import { Expose } from 'class-transformer';
+import { IsString, IsOptional } from 'class-validator';
+
 import { PaginationType } from '../interface';
 
 interface PaginationQuery {
@@ -14,6 +17,11 @@ export abstract class AbstractPaginationRequest {
     private _nextCursor: string;
 
     type: PaginationType;
+
+    @Expose({ name: 'nextCursor' })
+    @IsString()
+    @IsOptional()
+    query: string;
 
     setWhere(where: string | undefined) {
         if (!where) {

--- a/src/lib/abstract/abstract.pagination.spec.ts
+++ b/src/lib/abstract/abstract.pagination.spec.ts
@@ -1,0 +1,26 @@
+import { AbstractPaginationRequest } from './abstract.pagination';
+
+describe('AbstractPaginationRequest', () => {
+    class PaginationRequest extends AbstractPaginationRequest {
+        nextTotal(_dataLength?: number | undefined): number {
+            throw new Error('Method not implemented.');
+        }
+    }
+    it('should do nothing when where is undefined', () => {
+        const paginationRequest = new PaginationRequest();
+        paginationRequest.setWhere(undefined);
+        expect(paginationRequest.where).toBeUndefined();
+
+        paginationRequest.setWhere('where');
+        expect(paginationRequest.where).toEqual('where');
+
+        paginationRequest.setWhere(undefined);
+        expect(paginationRequest.where).toEqual('where');
+    });
+
+    it('should do nothing when query is invalid', () => {
+        const paginationRequest = new PaginationRequest();
+        paginationRequest.setQuery('invalid');
+        expect(paginationRequest.isNext).toBeFalsy();
+    });
+});

--- a/src/lib/abstract/abstract.pagination.ts
+++ b/src/lib/abstract/abstract.pagination.ts
@@ -10,6 +10,10 @@ interface PaginationQuery {
 }
 const encoding = 'base64';
 
+export interface PaginationAbstractResponse<T> {
+    data: T[];
+}
+
 export abstract class AbstractPaginationRequest {
     private _isNext: boolean = false;
     private _where: string;
@@ -40,7 +44,7 @@ export abstract class AbstractPaginationRequest {
         ).toString(encoding);
     }
 
-    setQuery(query: string) {
+    setQuery(query: string): void {
         try {
             const paginationType: PaginationQuery = JSON.parse(Buffer.from(query, encoding).toString());
             this._where = paginationType.where;
@@ -49,7 +53,7 @@ export abstract class AbstractPaginationRequest {
 
             this._isNext = true;
         } catch {
-            return {} as PaginationQuery;
+            //
         }
     }
 

--- a/src/lib/abstract/abstract.request.interceptor.spec.ts
+++ b/src/lib/abstract/abstract.request.interceptor.spec.ts
@@ -18,7 +18,7 @@ describe('RequestAbstractInterceptor', () => {
         id: number;
     }
 
-    beforeEach(() => {
+    beforeAll(() => {
         class FooInterceptor extends RequestAbstractInterceptor {
             constructor(crudLogger: CrudLogger) {
                 super(crudLogger);

--- a/src/lib/abstract/index.ts
+++ b/src/lib/abstract/index.ts
@@ -1,1 +1,2 @@
 export * from './abstract.request.interceptor';
+export * from './abstract.pagination-request';

--- a/src/lib/abstract/index.ts
+++ b/src/lib/abstract/index.ts
@@ -1,2 +1,2 @@
 export * from './abstract.request.interceptor';
-export * from './abstract.pagination-request';
+export * from './abstract.pagination';

--- a/src/lib/capitalize-first-letter.ts
+++ b/src/lib/capitalize-first-letter.ts
@@ -1,0 +1,1 @@
+export const capitalizeFirstLetter = (raw: string) => `${raw.charAt(0).toUpperCase()}${raw.slice(1)}`;

--- a/src/lib/crud.policy.ts
+++ b/src/lib/crud.policy.ts
@@ -1,5 +1,6 @@
 import { HttpStatus, NestInterceptor, RequestMethod, Type } from '@nestjs/common';
 
+import { capitalizeFirstLetter } from './capitalize-first-letter';
 import { ReadOneRequestInterceptor, CreateRequestInterceptor } from './interceptor';
 import { DeleteRequestInterceptor } from './interceptor/delete-request.interceptor';
 import { ReadManyRequestInterceptor } from './interceptor/read-many-request.interceptor';
@@ -8,7 +9,6 @@ import { SearchRequestInterceptor } from './interceptor/search-request.intercept
 import { UpdateRequestInterceptor } from './interceptor/update-request.interceptor';
 import { UpsertRequestInterceptor } from './interceptor/upsert-request.interceptor';
 import { CrudOptions, Method, PrimaryKey, FactoryOption, Sort, PaginationType } from './interface';
-import { capitalizeFirstLetter } from './util';
 
 type CrudMethodPolicy = {
     [Method.READ_ONE]: MethodPolicy<Method.READ_ONE>;

--- a/src/lib/crud.policy.ts
+++ b/src/lib/crud.policy.ts
@@ -54,12 +54,11 @@ const metaProperties = (paginationType: PaginationType) =>
               pages: { type: 'number', example: 1 },
               total: { type: 'number', example: 100 },
               offset: { type: 'number', example: 20 },
-              query: { type: 'string', example: 'queryToken' },
+              nextCursor: { type: 'string', example: 'cursorToken' },
           }
         : {
               total: { type: 'number', example: 100 },
               limit: { type: 'number', example: 20 },
-              query: { type: 'string', example: 'queryToken' },
               nextCursor: { type: 'string', example: 'cursorToken' },
           };
 /**

--- a/src/lib/crud.route.factory.ts
+++ b/src/lib/crud.route.factory.ts
@@ -13,6 +13,7 @@ import { DECORATORS } from '@nestjs/swagger/dist/constants';
 import { BaseEntity, getMetadataArgsStorage } from 'typeorm';
 import { MetadataUtils } from 'typeorm/metadata-builder/MetadataUtils';
 
+import { capitalizeFirstLetter } from './capitalize-first-letter';
 import { CRUD_ROUTE_ARGS } from './constants';
 import { CRUD_POLICY } from './crud.policy';
 import { RequestSearchDto } from './dto/request-search.dto';
@@ -33,7 +34,6 @@ import {
 } from './interface';
 import { CrudLogger } from './provider/crud-logger';
 import { CrudReadManyRequest } from './request';
-import { capitalizeFirstLetter, isSomeEnum } from './util';
 
 export class CrudRouteFactory {
     private crudLogger: CrudLogger;
@@ -51,7 +51,11 @@ export class CrudRouteFactory {
         this.entityInformation(crudOptions.entity);
 
         const paginationType = crudOptions.routes?.readMany?.paginationType ?? CRUD_POLICY[Method.READ_MANY].default.paginationType;
-        const isPaginationType = isSomeEnum(PaginationType);
+        const isPaginationType = (
+            <TEnum extends Record<string, unknown>>(enumType: TEnum) =>
+            (nextCursor: unknown): nextCursor is TEnum[keyof TEnum] =>
+                Object.values(enumType).includes(nextCursor as TEnum[keyof TEnum])
+        )(PaginationType);
         if (!isPaginationType(paginationType)) {
             throw new TypeError(`invalid PaginationType ${paginationType}`);
         }

--- a/src/lib/crud.route.factory.ts
+++ b/src/lib/crud.route.factory.ts
@@ -24,7 +24,6 @@ import {
     CrudOptions,
     CrudReadOneRequest,
     CrudRecoverRequest,
-    CrudSearchRequest,
     CrudUpdateOneRequest,
     FactoryOption,
     Method,
@@ -117,8 +116,8 @@ export class CrudRouteFactory {
     }
 
     protected search<T>(controllerMethodName: string) {
-        this.targetPrototype[controllerMethodName] = function reservedSearch(crudSearchRequest: CrudSearchRequest<T>) {
-            return this.crudService.reservedSearch(crudSearchRequest);
+        this.targetPrototype[controllerMethodName] = function reservedReadMany(crudReadManyRequest: CrudReadManyRequest<T>) {
+            return this.crudService.reservedReadMany(crudReadManyRequest);
         };
     }
 

--- a/src/lib/crud.service.spec.ts
+++ b/src/lib/crud.service.spec.ts
@@ -14,7 +14,7 @@ describe('CrudService', () => {
         const crudService = new CrudService<BaseEntity>(mockRepository as unknown as Repository<BaseEntity>);
         const mockEntity = { id: 1, name: 'name1' };
 
-        beforeEach(() => {
+        beforeAll(() => {
             mockRepository.findOne.mockResolvedValueOnce(mockEntity);
         });
 

--- a/src/lib/crud.service.spec.ts
+++ b/src/lib/crud.service.spec.ts
@@ -50,4 +50,17 @@ describe('CrudService', () => {
             ).rejects.toThrow(ConflictException);
         });
     });
+
+    describe('reservedReadMany', () => {
+        it('should log error and throw error when error occurred', async () => {
+            const mockRepository = {
+                metadata: {
+                    primaryColumns: [{ propertyName: 'id' }],
+                },
+                find: jest.fn(),
+            };
+            const crudService = new CrudService<BaseEntity>(mockRepository as unknown as Repository<BaseEntity>);
+            await expect(crudService.reservedReadMany({ key: 'value', array: [{ key: 'value' }] } as any)).rejects.toThrow(Error);
+        });
+    });
 });

--- a/src/lib/crud.service.ts
+++ b/src/lib/crud.service.ts
@@ -42,7 +42,7 @@ export class CrudService<T extends BaseEntity> {
             })();
             return crudReadManyRequest.toResponse(entities, total);
         } catch (error) {
-            Logger.error(crudReadManyRequest.toString());
+            Logger.error(JSON.stringify(crudReadManyRequest));
             Logger.error(error);
             throw error;
         }

--- a/src/lib/dto/index.ts
+++ b/src/lib/dto/index.ts
@@ -1,0 +1,6 @@
+export * from './pagination-cursor.dto';
+export * from './pagination-offset.dto';
+export * from './params.dto';
+export * from './request-fields.dto';
+export * from './request-search.dto';
+export * from './request.dto';

--- a/src/lib/dto/pagination-cursor.dto.ts
+++ b/src/lib/dto/pagination-cursor.dto.ts
@@ -7,11 +7,6 @@ import { PaginationType } from '../interface';
 export class PaginationCursorDto extends AbstractPaginationRequest {
     type: PaginationType.CURSOR = PaginationType.CURSOR;
 
-    @Expose({ name: 'nextCursor' })
-    @IsString()
-    @IsOptional()
-    nextCursor?: string;
-
     @Expose({ name: 'query' })
     @IsString()
     @IsOptional()

--- a/src/lib/dto/pagination-cursor.dto.ts
+++ b/src/lib/dto/pagination-cursor.dto.ts
@@ -1,9 +1,10 @@
 import { Expose } from 'class-transformer';
 import { IsOptional, IsString } from 'class-validator';
 
-import { PaginationRequestAbstract, PaginationType } from '../interface';
+import { AbstractPaginationRequest } from '../abstract';
+import { PaginationType } from '../interface';
 
-export class PaginationCursorDto implements PaginationRequestAbstract {
+export class PaginationCursorDto extends AbstractPaginationRequest {
     type: PaginationType.CURSOR = PaginationType.CURSOR;
 
     @Expose({ name: 'nextCursor' })
@@ -15,4 +16,8 @@ export class PaginationCursorDto implements PaginationRequestAbstract {
     @IsString()
     @IsOptional()
     query: string;
+
+    nextTotal(dataLength: number): number {
+        return this.total - dataLength;
+    }
 }

--- a/src/lib/dto/pagination-cursor.dto.ts
+++ b/src/lib/dto/pagination-cursor.dto.ts
@@ -1,16 +1,8 @@
-import { Expose } from 'class-transformer';
-import { IsOptional, IsString } from 'class-validator';
-
 import { AbstractPaginationRequest } from '../abstract';
 import { PaginationType } from '../interface';
 
 export class PaginationCursorDto extends AbstractPaginationRequest {
     type: PaginationType.CURSOR = PaginationType.CURSOR;
-
-    @Expose({ name: 'query' })
-    @IsString()
-    @IsOptional()
-    query: string;
 
     nextTotal(dataLength: number): number {
         return this.total - dataLength;

--- a/src/lib/dto/pagination-offset.dto.spec.ts
+++ b/src/lib/dto/pagination-offset.dto.spec.ts
@@ -18,13 +18,13 @@ describe('PaginationOffsetDto', () => {
 
         expect(validateSync(plainToInstance(PaginationOffsetDto, { limit: 100 }))).toEqual([]);
         expect(validateSync(plainToInstance(PaginationOffsetDto, { limit: 100, offset: 20 }))).toEqual([]);
-        expect(validateSync(plainToInstance(PaginationOffsetDto, { limit: 100, offset: 20, query: 'queryToken' }))).toEqual([]);
+        expect(validateSync(plainToInstance(PaginationOffsetDto, { limit: 100, offset: 20, nextCursor: 'queryToken' }))).toEqual([]);
     });
 
     it('should be positive number', () => {
         expect(validateSync(plainToInstance(PaginationOffsetDto, { limit: 10 }))).toEqual([]);
         expect(validateSync(plainToInstance(PaginationOffsetDto, { offset: 10 }))).toEqual([]);
-        expect(validateSync(plainToInstance(PaginationOffsetDto, { query: 10 }))).toEqual([
+        expect(validateSync(plainToInstance(PaginationOffsetDto, { nextCursor: 10 }))).toEqual([
             {
                 children: [],
                 constraints: { isString: 'query must be a string' },

--- a/src/lib/dto/pagination-offset.dto.spec.ts
+++ b/src/lib/dto/pagination-offset.dto.spec.ts
@@ -29,7 +29,7 @@ describe('PaginationOffsetDto', () => {
                 children: [],
                 constraints: { isString: 'query must be a string' },
                 property: 'query',
-                target: { query: 10, type: 'offset' },
+                target: { query: 10, type: 'offset', _isNext: false },
                 value: 10,
             },
         ]);
@@ -38,7 +38,7 @@ describe('PaginationOffsetDto', () => {
     it('should be character type', () => {
         expect(validateSync(plainToInstance(PaginationOffsetDto, { limit: 'a' }))).toEqual([
             {
-                target: { limit: Number.NaN, type: 'offset' },
+                target: { limit: Number.NaN, type: 'offset', _isNext: false },
                 value: Number.NaN,
                 property: 'limit',
                 children: [],
@@ -51,7 +51,7 @@ describe('PaginationOffsetDto', () => {
 
         expect(validateSync(plainToInstance(PaginationOffsetDto, { offset: 'b' }))).toEqual([
             {
-                target: { offset: Number.NaN, type: 'offset' },
+                target: { offset: Number.NaN, type: 'offset', _isNext: false },
                 value: Number.NaN,
                 property: 'offset',
                 children: [],
@@ -66,7 +66,7 @@ describe('PaginationOffsetDto', () => {
 
         expect(validateSync(plainToInstance(PaginationOffsetDto, { limit: 101 }))).toEqual([
             {
-                target: { limit: 101, type: 'offset' },
+                target: { limit: 101, type: 'offset', _isNext: false },
                 value: 101,
                 property: 'limit',
                 children: [],
@@ -77,9 +77,9 @@ describe('PaginationOffsetDto', () => {
     });
 
     it('should be allowed zero', () => {
-        expect(validateByPaginationOffsetDto({ limit: 1 })).toEqual({ limit: 1, type: 'offset' });
-        expect(validateByPaginationOffsetDto({ limit: 0 })).toEqual({ limit: 0, type: 'offset' });
-        expect(validateByPaginationOffsetDto({ limit: -1 })).toEqual({ limit: 0, type: 'offset' });
-        expect(validateByPaginationOffsetDto({})).toEqual({ type: 'offset' });
+        expect(validateByPaginationOffsetDto({ limit: 1 })).toEqual({ limit: 1, type: 'offset', _isNext: false });
+        expect(validateByPaginationOffsetDto({ limit: 0 })).toEqual({ limit: 0, type: 'offset', _isNext: false });
+        expect(validateByPaginationOffsetDto({ limit: -1 })).toEqual({ limit: 0, type: 'offset', _isNext: false });
+        expect(validateByPaginationOffsetDto({})).toEqual({ type: 'offset', _isNext: false });
     });
 });

--- a/src/lib/dto/pagination-offset.dto.ts
+++ b/src/lib/dto/pagination-offset.dto.ts
@@ -1,9 +1,10 @@
 import { Expose, Transform, Type } from 'class-transformer';
 import { IsNumber, IsOptional, IsPositive, IsString, Max } from 'class-validator';
 
-import { PaginationRequestAbstract, PaginationType } from '../interface';
+import { AbstractPaginationRequest } from '../abstract';
+import { PaginationType } from '../interface';
 
-export class PaginationOffsetDto implements PaginationRequestAbstract {
+export class PaginationOffsetDto extends AbstractPaginationRequest {
     type: PaginationType.OFFSET = PaginationType.OFFSET;
 
     @Expose({ name: 'limit' })
@@ -24,4 +25,8 @@ export class PaginationOffsetDto implements PaginationRequestAbstract {
     @IsString()
     @IsOptional()
     query?: string;
+
+    nextTotal(): number {
+        return this.total;
+    }
 }

--- a/src/lib/dto/pagination-offset.dto.ts
+++ b/src/lib/dto/pagination-offset.dto.ts
@@ -1,5 +1,5 @@
 import { Expose, Transform, Type } from 'class-transformer';
-import { IsNumber, IsOptional, IsPositive, IsString, Max } from 'class-validator';
+import { IsNumber, IsOptional, IsPositive, Max } from 'class-validator';
 
 import { AbstractPaginationRequest } from '../abstract';
 import { PaginationType } from '../interface';
@@ -20,11 +20,6 @@ export class PaginationOffsetDto extends AbstractPaginationRequest {
     @Type(() => Number)
     @IsOptional()
     offset?: number;
-
-    @Expose({ name: 'query' })
-    @IsString()
-    @IsOptional()
-    query?: string;
 
     nextTotal(): number {
         return this.total;

--- a/src/lib/dto/request.dto.ts
+++ b/src/lib/dto/request.dto.ts
@@ -5,8 +5,8 @@ import { getMetadataStorage, MetadataStorage } from 'class-validator';
 import { ValidationMetadata } from 'class-validator/types/metadata/ValidationMetadata';
 import { BaseEntity } from 'typeorm';
 
+import { capitalizeFirstLetter } from '../capitalize-first-letter';
 import { Method } from '../interface';
-import { capitalizeFirstLetter } from '../util';
 
 export function CreateRequestDto(parentClass: typeof BaseEntity, group: Method) {
     const propertyNamesAppliedValidation = getPropertyNamesFromMetadata(parentClass, group);

--- a/src/lib/interceptor/read-many-request.interceptor.spec.ts
+++ b/src/lib/interceptor/read-many-request.interceptor.spec.ts
@@ -7,7 +7,6 @@ import { BaseEntity } from 'typeorm';
 
 import { ReadManyRequestInterceptor } from './read-many-request.interceptor';
 import { CUSTOM_REQUEST_OPTIONS } from '../constants';
-import { PaginationType } from '../interface';
 import { ExecutionContextHost } from '../provider';
 import { CrudLogger } from '../provider/crud-logger';
 
@@ -31,17 +30,6 @@ describe('ReadManyRequestInterceptor', () => {
         expect(async () => {
             await interceptor.intercept(new ExecutionContextHost([{ [CUSTOM_REQUEST_OPTIONS]: {} }]), handler);
         }).not.toThrowError();
-    });
-
-    it('should be able to return pagination for GET_MORE type', () => {
-        const Interceptor = ReadManyRequestInterceptor({ entity: {} as typeof BaseEntity }, { relations: [], logger: new CrudLogger() });
-        const interceptor = new Interceptor();
-
-        expect(interceptor.getPaginationRequest(PaginationType.CURSOR, { key: 'value', nextCursor: 'token' })).toEqual({
-            nextCursor: 'token',
-            query: btoa('{}'),
-            type: 'cursor',
-        });
     });
 
     it('should be able to fields validation from entity columns', async () => {
@@ -106,16 +94,5 @@ describe('ReadManyRequestInterceptor', () => {
         expect(interceptorWithFalseOptions.getRelations({ relations: [] })).toEqual([]);
         expect(interceptorWithFalseOptions.getRelations({ relations: ['table'] })).toEqual(['table']);
         expect(interceptorWithFalseOptions.getRelations({})).toEqual([]);
-    });
-
-    it('should be validate pagination query', () => {
-        const Interceptor = ReadManyRequestInterceptor({ entity: {} as typeof BaseEntity }, { relations: [], logger: new CrudLogger() });
-        const interceptor = new Interceptor();
-
-        interceptor.getPaginationRequest(PaginationType.CURSOR, undefined as any);
-        expect(() => interceptor.getPaginationRequest(PaginationType.CURSOR, { nextCursor: 3 })).toThrowError(UnprocessableEntityException);
-
-        interceptor.getPaginationRequest(PaginationType.OFFSET, undefined as any);
-        expect(() => interceptor.getPaginationRequest(PaginationType.OFFSET, { limit: 200 })).toThrowError(UnprocessableEntityException);
     });
 });

--- a/src/lib/interceptor/read-many-request.interceptor.spec.ts
+++ b/src/lib/interceptor/read-many-request.interceptor.spec.ts
@@ -67,6 +67,20 @@ describe('ReadManyRequestInterceptor', () => {
         await expect(interceptor.validateQuery({ col1: 1 })).rejects.toThrow(UnprocessableEntityException);
         await expect(interceptor.validateQuery({ col2: '1' })).rejects.toThrow(UnprocessableEntityException);
         await expect(interceptor.validateQuery({ col1: 1, col2: '2', col3: 1 })).rejects.toThrow(UnprocessableEntityException);
+
+        // should be able to ignore limit and offset
+        expect(await interceptor.validateQuery({ col1: 1, col2: 2, limit: 3 })).toEqual({
+            col1: '1',
+            col2: 2,
+        });
+        expect(await interceptor.validateQuery({ col1: 1, col2: 2, offset: 10 })).toEqual({
+            col1: '1',
+            col2: 2,
+        });
+        expect(await interceptor.validateQuery({ col1: 1, col2: 2, limit: 3, offset: 10 })).toEqual({
+            col1: '1',
+            col2: 2,
+        });
     });
 
     it('should be get relation values per each condition', () => {

--- a/src/lib/interceptor/read-many-request.interceptor.ts
+++ b/src/lib/interceptor/read-many-request.interceptor.ts
@@ -70,6 +70,13 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
                 return {};
             }
 
+            if ('limit' in query) {
+                delete query.limit;
+            }
+            if ('offset' in query) {
+                delete query.offset;
+            }
+
             const transformed = plainToInstance(crudOptions.entity, query, { groups: [GROUP.READ_MANY] });
             const errorList = await validate(transformed, {
                 groups: [GROUP.READ_MANY],

--- a/src/lib/interceptor/search-request.interceptor.spec.ts
+++ b/src/lib/interceptor/search-request.interceptor.spec.ts
@@ -23,7 +23,7 @@ describe('SearchRequestInterceptor', () => {
     }
 
     let interceptor: any;
-    beforeEach(() => {
+    beforeAll(() => {
         const Interceptor = SearchRequestInterceptor(
             { entity: TestEntity },
             {

--- a/src/lib/interceptor/search-request.interceptor.spec.ts
+++ b/src/lib/interceptor/search-request.interceptor.spec.ts
@@ -106,9 +106,10 @@ describe('SearchRequestInterceptor', () => {
             });
         });
 
-        it('should throw when query filter is not an array or empty', async () => {
-            await expect(interceptor.validateBody({ where: [] })).rejects.toThrow(UnprocessableEntityException);
+        it('should throw when query filter is not an array', async () => {
+            await expect(interceptor.validateBody({ where: {} })).rejects.toThrow(UnprocessableEntityException);
             await expect(interceptor.validateBody({ where: [null] })).rejects.toThrow(UnprocessableEntityException);
+            await expect(interceptor.validateBody({ where: [undefined] })).rejects.toThrow(UnprocessableEntityException);
         });
 
         it('should throw when invalid query filter is given', async () => {

--- a/src/lib/interface/decorator-option.interface.ts
+++ b/src/lib/interface/decorator-option.interface.ts
@@ -102,6 +102,11 @@ export interface CrudOptions {
         } & Omit<RouteBaseOption, 'response'>;
         [Method.SEARCH]?: {
             /**
+             * Type of pagination to use. Currently 'offset' and 'cursor' are supported.
+             * @default PaginationType.CURSOR
+             */
+            paginationType?: PaginationType | `${PaginationType}`;
+            /**
              * Default number of entities should be taken. See `crud.policy.ts` for more details.
              * @default 20
              */

--- a/src/lib/interface/pagination.interface.ts
+++ b/src/lib/interface/pagination.interface.ts
@@ -14,10 +14,6 @@ export const PAGINATION_SWAGGER_QUERY: Record<PaginationType, Array<{ name: stri
     [PaginationType.CURSOR]: [{ name: 'nextCursor', type: 'string' }],
 };
 
-export interface PaginationRequestAbstract {
-    type: PaginationType;
-}
-
 export interface PaginationAbstractResponse<T> {
     data: T[];
 }

--- a/src/lib/interface/pagination.interface.ts
+++ b/src/lib/interface/pagination.interface.ts
@@ -1,3 +1,4 @@
+import { PaginationAbstractResponse } from '../abstract';
 import { PaginationCursorDto } from '../dto/pagination-cursor.dto';
 import { PaginationOffsetDto } from '../dto/pagination-offset.dto';
 
@@ -14,10 +15,6 @@ export const PAGINATION_SWAGGER_QUERY: Record<PaginationType, Array<{ name: stri
     ],
     [PaginationType.CURSOR]: [{ name: 'nextCursor', type: 'string' }],
 };
-
-export interface PaginationAbstractResponse<T> {
-    data: T[];
-}
 
 export interface CursorPaginationResponse<T> extends PaginationAbstractResponse<T> {
     metadata: {

--- a/src/lib/interface/pagination.interface.ts
+++ b/src/lib/interface/pagination.interface.ts
@@ -20,7 +20,6 @@ export interface PaginationAbstractResponse<T> {
 
 export interface CursorPaginationResponse<T> extends PaginationAbstractResponse<T> {
     metadata: {
-        query: string;
         limit: number;
         total: number;
         nextCursor: string;
@@ -30,22 +29,25 @@ export interface CursorPaginationResponse<T> extends PaginationAbstractResponse<
 export interface OffsetPaginationResponse<T> extends PaginationAbstractResponse<T> {
     metadata: {
         /**
-         * 현재 page 번호
+         * Current page number
          */
         page: number;
         /**
-         * 전체 page 개수
+         * Total page count
          */
         pages: number;
         /**
-         * 전체 데이터 개수
+         * Total data count
          */
         total: number;
         /**
-         * 한 페이지의 데이터 최대 개수
+         * Maximum number of data on a page
          */
         offset: number;
-        query: string;
+        /**
+         * cursor token for next page
+         */
+        nextCursor: string;
     };
 }
 

--- a/src/lib/interface/pagination.interface.ts
+++ b/src/lib/interface/pagination.interface.ts
@@ -10,6 +10,7 @@ export const PAGINATION_SWAGGER_QUERY: Record<PaginationType, Array<{ name: stri
     [PaginationType.OFFSET]: [
         { name: 'limit', type: 'integer' },
         { name: 'offset', type: 'integer' },
+        { name: 'nextCursor', type: 'string' },
     ],
     [PaginationType.CURSOR]: [{ name: 'nextCursor', type: 'string' }],
 };

--- a/src/lib/provider/pagination.helper.spec.ts
+++ b/src/lib/provider/pagination.helper.spec.ts
@@ -65,4 +65,8 @@ describe('Pagination Helper', () => {
             UnprocessableEntityException,
         );
     });
+
+    it('should be return empty object when nextCursor is undefined', () => {
+        expect(PaginationHelper.deserialize(undefined as any)).toEqual({});
+    });
 });

--- a/src/lib/provider/pagination.helper.spec.ts
+++ b/src/lib/provider/pagination.helper.spec.ts
@@ -20,8 +20,19 @@ describe('Pagination Helper', () => {
 
     it('should be able to return pagination for GET_MORE type', () => {
         expect(PaginationHelper.getPaginationRequest(PaginationType.CURSOR, { key: 'value', nextCursor: 'token' })).toEqual({
-            nextCursor: 'token',
-            query: btoa('{}'),
+            query: undefined,
+            type: 'cursor',
+            _isNext: false,
+        });
+
+        expect(PaginationHelper.getPaginationRequest(PaginationType.CURSOR, { key: 'value' })).toEqual({
+            query: undefined,
+            type: 'cursor',
+            _isNext: false,
+        });
+
+        expect(PaginationHelper.getPaginationRequest(PaginationType.CURSOR, { query: 'query' })).toEqual({
+            query: 'query',
             type: 'cursor',
             _isNext: false,
         });
@@ -30,13 +41,11 @@ describe('Pagination Helper', () => {
     it('should be validate pagination query', () => {
         expect(PaginationHelper.getPaginationRequest(PaginationType.CURSOR, undefined as any)).toEqual({
             type: 'cursor',
-            nextCursor: undefined,
             query: undefined,
             _isNext: false,
         });
-        expect(() => PaginationHelper.getPaginationRequest(PaginationType.CURSOR, { nextCursor: 3 })).toThrowError(
-            UnprocessableEntityException,
-        );
+
+        expect(() => PaginationHelper.getPaginationRequest(PaginationType.CURSOR, { query: 3 })).toThrowError(UnprocessableEntityException);
 
         expect(PaginationHelper.getPaginationRequest(PaginationType.OFFSET, undefined as any)).toEqual({
             type: 'offset',
@@ -45,6 +54,9 @@ describe('Pagination Helper', () => {
             query: undefined,
             _isNext: false,
         });
+
+        expect(() => PaginationHelper.getPaginationRequest(PaginationType.OFFSET, { query: 3 })).toThrowError(UnprocessableEntityException);
+
         expect(() => PaginationHelper.getPaginationRequest(PaginationType.OFFSET, { limit: 200 })).toThrowError(
             UnprocessableEntityException,
         );

--- a/src/lib/provider/pagination.helper.spec.ts
+++ b/src/lib/provider/pagination.helper.spec.ts
@@ -1,4 +1,7 @@
+import { UnprocessableEntityException } from '@nestjs/common';
+
 import { PaginationHelper } from './pagination.helper';
+import { PaginationType } from '../interface';
 
 describe('Pagination Helper', () => {
     it('should serialize entity', () => {
@@ -13,5 +16,37 @@ describe('Pagination Helper', () => {
     it('should return empty object when cursor is malformed', () => {
         const cursor = 'malformed';
         expect(PaginationHelper.deserialize(cursor)).toEqual({});
+    });
+
+    it('should be able to return pagination for GET_MORE type', () => {
+        expect(PaginationHelper.getPaginationRequest(PaginationType.CURSOR, { key: 'value', nextCursor: 'token' })).toEqual({
+            nextCursor: 'token',
+            query: btoa('{}'),
+            type: 'cursor',
+            _isNext: false,
+        });
+    });
+
+    it('should be validate pagination query', () => {
+        expect(PaginationHelper.getPaginationRequest(PaginationType.CURSOR, undefined as any)).toEqual({
+            type: 'cursor',
+            nextCursor: undefined,
+            query: undefined,
+            _isNext: false,
+        });
+        expect(() => PaginationHelper.getPaginationRequest(PaginationType.CURSOR, { nextCursor: 3 })).toThrowError(
+            UnprocessableEntityException,
+        );
+
+        expect(PaginationHelper.getPaginationRequest(PaginationType.OFFSET, undefined as any)).toEqual({
+            type: 'offset',
+            limit: undefined,
+            offset: undefined,
+            query: undefined,
+            _isNext: false,
+        });
+        expect(() => PaginationHelper.getPaginationRequest(PaginationType.OFFSET, { limit: 200 })).toThrowError(
+            UnprocessableEntityException,
+        );
     });
 });

--- a/src/lib/provider/pagination.helper.spec.ts
+++ b/src/lib/provider/pagination.helper.spec.ts
@@ -20,7 +20,7 @@ describe('Pagination Helper', () => {
 
     it('should be able to return pagination for GET_MORE type', () => {
         expect(PaginationHelper.getPaginationRequest(PaginationType.CURSOR, { key: 'value', nextCursor: 'token' })).toEqual({
-            query: undefined,
+            query: 'token',
             type: 'cursor',
             _isNext: false,
         });
@@ -32,7 +32,7 @@ describe('Pagination Helper', () => {
         });
 
         expect(PaginationHelper.getPaginationRequest(PaginationType.CURSOR, { query: 'query' })).toEqual({
-            query: 'query',
+            query: undefined,
             type: 'cursor',
             _isNext: false,
         });
@@ -45,7 +45,9 @@ describe('Pagination Helper', () => {
             _isNext: false,
         });
 
-        expect(() => PaginationHelper.getPaginationRequest(PaginationType.CURSOR, { query: 3 })).toThrowError(UnprocessableEntityException);
+        expect(() => PaginationHelper.getPaginationRequest(PaginationType.CURSOR, { nextCursor: 3 })).toThrowError(
+            UnprocessableEntityException,
+        );
 
         expect(PaginationHelper.getPaginationRequest(PaginationType.OFFSET, undefined as any)).toEqual({
             type: 'offset',
@@ -55,7 +57,9 @@ describe('Pagination Helper', () => {
             _isNext: false,
         });
 
-        expect(() => PaginationHelper.getPaginationRequest(PaginationType.OFFSET, { query: 3 })).toThrowError(UnprocessableEntityException);
+        expect(() => PaginationHelper.getPaginationRequest(PaginationType.OFFSET, { nextCursor: 3 })).toThrowError(
+            UnprocessableEntityException,
+        );
 
         expect(() => PaginationHelper.getPaginationRequest(PaginationType.OFFSET, { limit: 200 })).toThrowError(
             UnprocessableEntityException,

--- a/src/lib/provider/pagination.helper.ts
+++ b/src/lib/provider/pagination.helper.ts
@@ -36,10 +36,6 @@ export class PaginationHelper {
             throw new UnprocessableEntityException(error);
         }
 
-        if (transformed.type === PaginationType.CURSOR && transformed.nextCursor && !transformed.query) {
-            transformed.query = btoa('{}');
-        }
-
         return transformed;
     }
 
@@ -50,12 +46,6 @@ export class PaginationHelper {
      * @returns boolean
      */
     static isNextPage(paginationRequest: PaginationRequest): boolean {
-        if (paginationRequest.type === PaginationType.CURSOR) {
-            return paginationRequest.nextCursor != null;
-        }
-        if (paginationRequest.type === PaginationType.OFFSET) {
-            return paginationRequest.offset != null || paginationRequest.limit != null || paginationRequest.query != null;
-        }
-        return false;
+        return paginationRequest.query != null;
     }
 }

--- a/src/lib/provider/pagination.helper.ts
+++ b/src/lib/provider/pagination.helper.ts
@@ -1,9 +1,15 @@
+import { UnprocessableEntityException } from '@nestjs/common';
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
 import { FindOptionsWhere } from 'typeorm';
+
+import { PaginationCursorDto, PaginationOffsetDto, RequestSearchDto } from '../dto';
+import { PaginationRequest, PaginationType } from '../interface';
 
 const encoding = 'base64';
 
 export class PaginationHelper {
-    static serialize<T>(entity: FindOptionsWhere<T>): string {
+    static serialize<T>(entity: FindOptionsWhere<T> | Array<FindOptionsWhere<T>> | RequestSearchDto<T> | Record<string, unknown>): string {
         return Buffer.from(JSON.stringify(entity)).toString(encoding);
     }
 
@@ -16,5 +22,40 @@ export class PaginationHelper {
         } catch {
             return {} as T;
         }
+    }
+
+    static getPaginationRequest(paginationType: PaginationType, query: Record<string, unknown>): PaginationRequest {
+        const plain = query ?? {};
+        const transformed =
+            paginationType === PaginationType.OFFSET
+                ? plainToInstance(PaginationOffsetDto, plain, { excludeExtraneousValues: true })
+                : plainToInstance(PaginationCursorDto, plain, { excludeExtraneousValues: true });
+        const [error] = validateSync(transformed, { stopAtFirstError: true });
+
+        if (error) {
+            throw new UnprocessableEntityException(error);
+        }
+
+        if (transformed.type === PaginationType.CURSOR && transformed.nextCursor && !transformed.query) {
+            transformed.query = btoa('{}');
+        }
+
+        return transformed;
+    }
+
+    /**
+     * [EN] Check if the request is requesting the next page.
+     * [KR] Request 요청이 다음 페이지를 요청하는지 확인합니다.
+     * @param paginationRequest
+     * @returns boolean
+     */
+    static isNextPage(paginationRequest: PaginationRequest): boolean {
+        if (paginationRequest.type === PaginationType.CURSOR) {
+            return paginationRequest.nextCursor != null;
+        }
+        if (paginationRequest.type === PaginationType.OFFSET) {
+            return paginationRequest.offset != null || paginationRequest.limit != null || paginationRequest.query != null;
+        }
+        return false;
     }
 }

--- a/src/lib/request/read-many.request.ts
+++ b/src/lib/request/read-many.request.ts
@@ -123,9 +123,9 @@ export class CrudReadManyRequest<T> {
                 metadata: {
                     page: this.pagination.offset ? Math.floor(this.pagination.offset / this.findOptions.take) + 1 : 1,
                     pages: total ? Math.ceil(total / this.findOptions.take) : 1,
-                    total,
                     offset: (this.pagination.offset ?? 0) + data.length,
-                    query: this.pagination.makeQuery(total, nextCursor),
+                    total,
+                    nextCursor: this.pagination.makeQuery(total, nextCursor),
                 },
             };
         }
@@ -133,10 +133,9 @@ export class CrudReadManyRequest<T> {
         return {
             data,
             metadata: {
-                nextCursor,
                 limit: this.findOptions.take,
                 total,
-                query: this.pagination.makeQuery(total, nextCursor),
+                nextCursor: this.pagination.makeQuery(total, nextCursor),
             },
         };
     }

--- a/src/lib/request/read-many.request.ts
+++ b/src/lib/request/read-many.request.ts
@@ -1,18 +1,25 @@
 import _ from 'lodash';
-import { FindManyOptions, FindOptionsWhere, LessThan, MoreThan } from 'typeorm';
+import { FindManyOptions, FindOptionsOrder, FindOptionsSelect, FindOptionsSelectByString, FindOptionsWhere } from 'typeorm';
 
 import { CRUD_POLICY } from '../crud.policy';
 import { Method, PaginationRequest, PaginationResponse, PaginationType, PrimaryKey, Sort } from '../interface';
 import { PaginationHelper } from '../provider';
 
+type Where<T> = FindOptionsWhere<T> | Array<FindOptionsWhere<T>>;
 export class CrudReadManyRequest<T> {
     private _primaryKeys: PrimaryKey[] = [];
-    private _findOptions: FindManyOptions<T> & { where: FindOptionsWhere<T>; take: number } = {
+    private _findOptions: FindManyOptions<T> & {
+        where: Where<T>;
+        take: number;
+        order: FindOptionsOrder<T>;
+    } = {
         where: {},
         take: CRUD_POLICY[Method.READ_MANY].default.numberOfTake,
+        order: {},
     };
     private _sort: Sort;
     private _pagination: PaginationRequest;
+    private _deserialize: (crudReadManyRequest: CrudReadManyRequest<T>) => Where<T>;
 
     get primaryKeys() {
         return this._primaryKeys;
@@ -22,6 +29,10 @@ export class CrudReadManyRequest<T> {
     }
     get pagination() {
         return this._pagination;
+    }
+
+    get sort() {
+        return this._sort;
     }
 
     setPagination(pagination: PaginationRequest): this {
@@ -39,7 +50,13 @@ export class CrudReadManyRequest<T> {
         return this;
     }
 
-    setWhere(where: FindOptionsWhere<T> & Partial<T>): this {
+    // TODO: FindOptionsSelectByString is deprecated.
+    setSelect(select: FindOptionsSelect<T> | FindOptionsSelectByString<T> | undefined): this {
+        this._findOptions.select = select;
+        return this;
+    }
+
+    setWhere(where: (FindOptionsWhere<T> & Partial<T>) | Array<FindOptionsWhere<T>>): this {
         this._findOptions.where = where;
         return this;
     }
@@ -55,8 +72,19 @@ export class CrudReadManyRequest<T> {
         return this;
     }
 
+    setOrder(order: FindOptionsOrder<T>, sort: Sort): this {
+        this._sort = sort;
+        this._findOptions.order = order;
+        return this;
+    }
+
     setRelations(relations: string[] | undefined): this {
         this._findOptions.relations = relations;
+        return this;
+    }
+
+    setDeserialize(deserialize: (crudReadManyRequest: CrudReadManyRequest<T>) => FindOptionsWhere<T> | Array<FindOptionsWhere<T>>): this {
+        this._deserialize = deserialize;
         return this;
     }
 
@@ -66,23 +94,29 @@ export class CrudReadManyRequest<T> {
                 this._findOptions.take = this.pagination.limit;
             }
             if (Number.isFinite(this.pagination.offset)) {
-                this._findOptions.where = PaginationHelper.deserialize(this.pagination.query);
+                this._findOptions.where = this._deserialize(this);
                 this._findOptions.skip = this.pagination.offset;
             }
         }
 
         if (this.pagination.type === PaginationType.CURSOR && this.pagination.nextCursor) {
-            this._findOptions.where = this.paginateCursorWhereByNextCursor();
+            this._findOptions.where = this._deserialize(this);
         }
 
         return this;
     }
 
     toString(): string {
-        return JSON.stringify(this);
+        return JSON.stringify(_.omit(this, ['_deserialize']));
     }
 
     toResponse(data: T[], total: number): PaginationResponse<T> {
+        const nextCursor = PaginationHelper.serialize(
+            _.pick(
+                data.at(-1),
+                this.primaryKeys.map(({ name }) => name),
+            ) as FindOptionsWhere<T>,
+        );
         if (this.pagination.type === PaginationType.OFFSET) {
             return {
                 data,
@@ -91,37 +125,19 @@ export class CrudReadManyRequest<T> {
                     pages: total ? Math.ceil(total / this.findOptions.take) : 1,
                     total,
                     offset: (this.pagination.offset ?? 0) + data.length,
-                    query: this.pagination.query ?? PaginationHelper.serialize(this.findOptions.where),
+                    query: this.pagination.makeQuery(total, nextCursor),
                 },
             };
         }
+
         return {
             data,
             metadata: {
-                nextCursor: PaginationHelper.serialize(
-                    _.pick(
-                        data.at(-1),
-                        this.primaryKeys.map(({ name }) => name),
-                    ) as FindOptionsWhere<T>,
-                ),
+                nextCursor,
                 limit: this.findOptions.take,
                 total,
-                query: this.pagination.query ?? PaginationHelper.serialize(this.findOptions.where),
+                query: this.pagination.makeQuery(total, nextCursor),
             },
         };
-    }
-
-    private paginateCursorWhereByNextCursor(): FindOptionsWhere<T> {
-        if (this.pagination.type !== PaginationType.CURSOR) {
-            return {};
-        }
-        const query: Record<string, unknown> = PaginationHelper.deserialize(this.pagination.query);
-        const lastObject: Record<string, unknown> = PaginationHelper.deserialize(this.pagination.nextCursor);
-
-        const operator = this._sort === Sort.DESC ? LessThan : MoreThan;
-        for (const [key, value] of Object.entries(lastObject)) {
-            query[key] = operator(value);
-        }
-        return query as FindOptionsWhere<T>;
     }
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,6 +1,0 @@
-export const capitalizeFirstLetter = (raw: string) => `${raw.charAt(0).toUpperCase()}${raw.slice(1)}`;
-
-export const isSomeEnum =
-    <TEnum extends Record<string, unknown>>(enumType: TEnum) =>
-    (nextCursor: unknown): nextCursor is TEnum[keyof TEnum] =>
-        Object.values(enumType).includes(nextCursor as TEnum[keyof TEnum]);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [x] Feature
-   [x] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

- The `query`, `nextCursor` are combined into the `nextCursor`.
  + This causes a `breaking change`.
  + The nextCursor will manage information for pagination
  + In the near future, I hope to `use keySet for offset` pagination.

- Support for `offset pagination` in the search API.
  + search and readMany handle the same logic, just different interfaces.
  + Each interface is managed by its own interceptor.

- Improvements to the Total Count
  + the total value is reused.
  + This is a gain for `breaking change`

- Fix creating keySet conditions
  + `Next page does not work` when PrimaryKey is used as a condition in Search.

Reduced overall test time locally from 107.694 seconds to 84.078 seconds. (-21.93%)
  +  Reduce less time testing by reducing the cost of creating and managing resources each time, 
    Improve unitTest to `use beforeAll instead of beforeEach`.
  + Remove unnecessary tasks.
```
// AS-IS
Test Suites: 77 passed, 77 total
Tests:       239 passed, 239 total
Snapshots:   0 total
Time:        107.694 s
Ran all test suites.
✨  Done in 109.59s.

// TO-BE
Test Suites: 77 passed, 77 total
Tests:       244 passed, 244 total
Snapshots:   0 total
Time:        84.078 s, estimated 101 s
Ran all test suites.
✨  Done in 85.93s.
```

- Etc
   + Comments written in Korean have been removed or changed.
   + Allows for empty conditions for Search.

## Does this PR introduce a breaking change?

-   [x] Yes
-   [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Continued from https://github.com/woowabros/nestjs-library-crud/pull/244

I failed to manage PR size. 
This has so many changes in it that it will make reviewers suffer.