### PR TITLE
fix: should be used search without conditions

### DIFF
--- a/src/lib/interceptor/search-request.interceptor.ts
+++ b/src/lib/interceptor/search-request.interceptor.ts
@@ -62,7 +62,7 @@ export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption
                     ? requestSearchDto.where.map((queryFilter, index) =>
                           TypeOrmQueryBuilderHelper.queryFilterToFindOptionsWhere(queryFilter, index),
                       )
-                    : {};
+                    : [];
 
             const primaryKeys = factoryOption.primaryKeys ?? [];
             requestSearchDto.order ??= primaryKeys.reduce((acc, { name }) => ({ ...acc, [name]: CRUD_POLICY[method].default.sort }), {});
@@ -265,7 +265,6 @@ export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption
             if (pagination.type === PaginationType.OFFSET) {
                 return where;
             }
-
             const lastObject: Record<string, unknown> = PaginationHelper.deserialize(pagination.nextCursor);
 
             const operator = (key: keyof T) => ((findOptions.order?.[key] ?? sort) === Sort.DESC ? LessThan : MoreThan);
@@ -287,6 +286,7 @@ export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption
                     );
                 }
             }
+            where.push(cursorCondition);
             return where;
         }
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


1. If use `search` without conditions, a `where is not iterable` error occur.
2. If use `search` without conditions, the next cursor position will not be searched.

## What is the new behavior?

should be used search without conditions.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
