### PR TITLE
feat: throw confilctException, when query error occurs

### DIFF
--- a/spec/unique-key/unique.controller.create.mysql.spec.ts
+++ b/spec/unique-key/unique.controller.create.mysql.spec.ts
@@ -38,4 +38,14 @@ describe('UniqueController', () => {
             await request(app.getHttpServer()).post('/unique').send(toCreate).expect(HttpStatus.CONFLICT);
         });
     });
+
+    describe('UPDATE', () => {
+        it('should throw when cannot update duplicated entities', async () => {
+            const name = 'name1';
+            await request(app.getHttpServer()).post('/unique').send({ name }).expect(HttpStatus.CREATED);
+            const { body: created } = await request(app.getHttpServer()).post('/unique').send({ name: 'name2' }).expect(HttpStatus.CREATED);
+            await request(app.getHttpServer()).patch(`/unique/${created.id}`).send({ name }).expect(HttpStatus.CONFLICT);
+            await request(app.getHttpServer()).patch(`/unique/${created.id}`).send({ name: 'name3' }).expect(HttpStatus.OK);
+        });
+    });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

When a query error such as  duplicate error, the error is not thrown properly.

## What is the new behavior?

If data manipulation fails, ConflictError is thrown

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
