### PR TITLE
Redefines the total of cursor pagination.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nestjs-library/crud",
-    "version": "0.8.4",
+    "version": "0.8.6",
     "description": "Automatically generate CRUD Rest API based on NestJS and TypeOrm",
     "homepage": "https://github.com/woowabros/nestjs-library-crud",
     "repository": {

--- a/spec/pagination/pagination.spec.ts
+++ b/spec/pagination/pagination.spec.ts
@@ -138,7 +138,7 @@ describe('Pagination', () => {
             expect(nextResponseBody.metadata).toEqual({
                 nextCursor: expect.any(String),
                 limit: defaultLimit,
-                total: totalCount - defaultLimit,
+                total: totalCount,
             });
 
             const lastOneOfFirstResponse = firstResponseBody.data.pop();
@@ -179,7 +179,7 @@ describe('Pagination', () => {
             expect(nextResponseBody.metadata).toEqual({
                 nextCursor: expect.any(String),
                 limit: defaultLimit,
-                total: totalCount - defaultLimit,
+                total: totalCount,
             });
             expect(nextResponseBody.metadata.nextCursor).not.toEqual(responseBody.metadata.nextCursor);
 

--- a/spec/read-many/read-many.controller.spec.ts
+++ b/spec/read-many/read-many.controller.spec.ts
@@ -109,8 +109,8 @@ describe('ReadMany - Options', () => {
             expect(secondNextResponse.metadata.nextCursor).toEqual(expect.any(String));
             expect(secondNextResponse.metadata.nextCursor).not.toEqual(firstResponse.metadata.nextCursor);
 
-            expect(nextResponse.metadata.total).toEqual(firstResponse.metadata.total - nextResponse.metadata.limit);
-            expect(secondNextResponse.metadata.total).toEqual(nextResponse.metadata.total - secondNextResponse.metadata.limit);
+            expect(nextResponse.metadata.total).toEqual(firstResponse.metadata.total);
+            expect(secondNextResponse.metadata.total).toEqual(nextResponse.metadata.total);
 
             expect(nextResponse.data).toHaveLength(defaultLimit);
             expect(nextResponse.metadata.nextCursor).toBeDefined();

--- a/spec/search/search-cursor-pagination.spec.ts
+++ b/spec/search/search-cursor-pagination.spec.ts
@@ -221,7 +221,7 @@ describe('Search Cursor Pagination', () => {
             ],
             metadata: {
                 limit: 5,
-                total: 20,
+                total: 25,
                 nextCursor: expect.any(String),
             },
         });

--- a/src/lib/abstract/abstract.pagination.spec.ts
+++ b/src/lib/abstract/abstract.pagination.spec.ts
@@ -3,7 +3,7 @@ import { PaginationResponse } from '../interface';
 
 describe('AbstractPaginationRequest', () => {
     class PaginationRequest extends AbstractPaginationRequest {
-        nextTotal(_dataLength?: number | undefined): number {
+        nextTotal(): number {
             throw new Error('Method not implemented.');
         }
         metadata<T>(_take: number, _dataLength: number, _total: number, _nextCursor: string): PaginationResponse<T>['metadata'] {

--- a/src/lib/abstract/abstract.pagination.ts
+++ b/src/lib/abstract/abstract.pagination.ts
@@ -73,6 +73,6 @@ export abstract class AbstractPaginationRequest {
         return this._nextCursor;
     }
 
-    abstract nextTotal(dataLength?: number): number;
+    abstract nextTotal(): number;
     abstract metadata<T>(take: number, dataLength: number, total: number, nextCursor: string): PaginationResponse<T>['metadata'];
 }

--- a/src/lib/crud.service.ts
+++ b/src/lib/crud.service.ts
@@ -33,7 +33,7 @@ export class CrudService<T extends BaseEntity> {
 
                 if (crudReadManyRequest.pagination.isNext) {
                     const entities = await findEntities;
-                    return { entities, total: crudReadManyRequest.pagination.nextTotal(entities.length) };
+                    return { entities, total: crudReadManyRequest.pagination.nextTotal() };
                 }
                 const [entities, total] = await Promise.all([
                     findEntities,

--- a/src/lib/dto/pagination-cursor.dto.ts
+++ b/src/lib/dto/pagination-cursor.dto.ts
@@ -4,8 +4,8 @@ import { CursorPaginationResponse, PaginationType } from '../interface';
 export class PaginationCursorDto extends AbstractPaginationRequest {
     type: PaginationType.CURSOR = PaginationType.CURSOR;
 
-    nextTotal(dataLength: number): number {
-        return this.total - dataLength;
+    nextTotal(): number {
+        return this.total;
     }
 
     metadata<T>(take: number, _dataLength: number, total: number, nextCursor: string): CursorPaginationResponse<T>['metadata'] {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The total of cursor pagination and offset pagination are different.

The total of offset pagination uses the total value of the first page as is, 
but the total of cursor pagination uses the value `minus the number of data`.


```
first page  (data length is 50)
- total count(88)
next page (data length is 33)
- prev page total count(88) - data count(33) = 50
next page (data length is 0)
- prev page total count(50) - data count(0) = 50
```

## What is the new behavior?

The total value of cursor pagination is used as the total value of the first page.

## Does this PR introduce a breaking change?

-   [x] Yes
-   [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
