### PR TITLE
fix: relations in crud option not work

### DIFF
--- a/spec/relation-entities/comment.entity.ts
+++ b/spec/relation-entities/comment.entity.ts
@@ -2,6 +2,7 @@ import { Type } from 'class-transformer';
 import { IsString, IsOptional, IsNotEmpty, IsNumber } from 'class-validator';
 import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
 
+import { QuestionEntity } from './question.entity';
 import { WriterEntity } from './writer.entity';
 import { GROUP } from '../../src';
 import { CrudAbstractEntity } from '../crud.abstract.entity';
@@ -14,6 +15,10 @@ export class CommentEntity extends CrudAbstractEntity {
     @IsNotEmpty({ groups: [GROUP.CREATE, GROUP.UPSERT] })
     @IsOptional({ groups: [GROUP.READ_MANY] })
     questionId: number;
+
+    @ManyToOne(() => QuestionEntity)
+    @JoinColumn({ name: 'questionId' })
+    question: QuestionEntity;
 
     @Column('varchar', { nullable: false })
     @IsString({ groups: [GROUP.CREATE, GROUP.UPDATE, GROUP.UPSERT] })

--- a/spec/relation-entities/question.entity.ts
+++ b/spec/relation-entities/question.entity.ts
@@ -1,8 +1,9 @@
 import { Type } from 'class-transformer';
 import { IsNotEmpty, IsNumber, IsOptional, IsString } from 'class-validator';
-import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
 
 import { CategoryEntity } from './category.entity';
+import { CommentEntity } from './comment.entity';
 import { WriterEntity } from './writer.entity';
 import { GROUP } from '../../src';
 import { CrudAbstractEntity } from '../crud.abstract.entity';
@@ -42,4 +43,7 @@ export class QuestionEntity extends CrudAbstractEntity {
     @IsNotEmpty({ groups: [GROUP.CREATE, GROUP.UPSERT] })
     @IsOptional({ groups: [GROUP.UPDATE, GROUP.SEARCH, GROUP.READ_MANY] })
     content: string;
+
+    @OneToMany(() => CommentEntity, (comment) => comment.question)
+    comments: CommentEntity[];
 }

--- a/spec/relation-entities/relation-entities-read.spec.ts
+++ b/spec/relation-entities/relation-entities-read.spec.ts
@@ -135,6 +135,7 @@ describe('Relation Entities Read', () => {
                 lastModifiedAt: writer1Body.lastModifiedAt,
                 name: writer1Body.name,
             },
+            comments: [comment1Body, comment2Body],
         });
 
         const { body: getQuestionBody } = await request(app.getHttpServer()).get(`/question/${questionBody.id}`).expect(HttpStatus.OK);
@@ -161,6 +162,7 @@ describe('Relation Entities Read', () => {
                 lastModifiedAt: writer1Body.lastModifiedAt,
                 name: writer1Body.name,
             },
+            comments: [comment1Body, comment2Body],
         });
 
         const { body: commentListBody } = await request(app.getHttpServer())
@@ -185,6 +187,7 @@ describe('Relation Entities Read', () => {
                     createdAt: comment.writerId === writer1Body.id ? writer1Body.createdAt : writer2Body.createdAt,
                     lastModifiedAt: comment.writerId === writer1Body.id ? writer1Body.lastModifiedAt : writer2Body.lastModifiedAt,
                 },
+                question: questionBody,
             });
         }
 
@@ -210,6 +213,7 @@ describe('Relation Entities Read', () => {
                     createdAt: comment.writerId === writer1Body.id ? writer1Body.createdAt : writer2Body.createdAt,
                     lastModifiedAt: comment.writerId === writer1Body.id ? writer1Body.lastModifiedAt : writer2Body.lastModifiedAt,
                 },
+                question: questionBody,
             });
         }
 
@@ -231,6 +235,7 @@ describe('Relation Entities Read', () => {
                 createdAt: commentBody.writerId === writer1Body.id ? writer1Body.createdAt : writer2Body.createdAt,
                 lastModifiedAt: commentBody.writerId === writer1Body.id ? writer1Body.lastModifiedAt : writer2Body.lastModifiedAt,
             },
+            question: questionBody,
         });
     });
 });

--- a/spec/relation-entities/relation-entities-search.spec.ts
+++ b/spec/relation-entities/relation-entities-search.spec.ts
@@ -14,7 +14,7 @@ describe('Relation Entities Search', () => {
                 RelationEntitiesModule({
                     category: {},
                     writer: {},
-                    question: { search: { relations: ['writer', 'category', 'comment'] } },
+                    question: { search: { relations: ['writer', 'category', 'comments'] } },
                     comment: {},
                 }),
             ],
@@ -52,11 +52,11 @@ describe('Relation Entities Search', () => {
             .expect(HttpStatus.CREATED);
 
         // Create 2 comments
-        await request(app.getHttpServer())
+        const { body: comment1Body } = await request(app.getHttpServer())
             .post('/comment')
             .send({ questionId: questionBody.id, message: 'Comment Message#1', writerId: writer2Body.id })
             .expect(HttpStatus.CREATED);
-        await request(app.getHttpServer())
+        const { body: comment2Body } = await request(app.getHttpServer())
             .post('/comment')
             .send({ questionId: questionBody.id, message: 'Comment Message#2', writerId: writer1Body.id })
             .expect(HttpStatus.CREATED);
@@ -94,6 +94,7 @@ describe('Relation Entities Search', () => {
                 lastModifiedAt: writer1Body.lastModifiedAt,
                 name: writer1Body.name,
             },
+            comments: [comment1Body, comment2Body],
         });
     });
 });

--- a/src/lib/interceptor/search-request.interceptor.spec.ts
+++ b/src/lib/interceptor/search-request.interceptor.spec.ts
@@ -256,7 +256,7 @@ describe('SearchRequestInterceptor', () => {
         expect(interceptor.getRelations({})).toEqual([]);
 
         const InterceptorWithOptions = SearchRequestInterceptor(
-            { entity: {} as typeof BaseEntity, routes: { readMany: { relations: ['option'] } } },
+            { entity: {} as typeof BaseEntity, routes: { search: { relations: ['option'] } } },
             { relations: [], logger: new CrudLogger() },
         );
         const interceptorWithOptions = new InterceptorWithOptions();
@@ -265,7 +265,7 @@ describe('SearchRequestInterceptor', () => {
         expect(interceptorWithOptions.getRelations({})).toEqual(['option']);
 
         const InterceptorWithFalseOptions = SearchRequestInterceptor(
-            { entity: {} as typeof BaseEntity, routes: { readMany: { relations: false } } },
+            { entity: {} as typeof BaseEntity, routes: { search: { relations: false } } },
             { relations: [], logger: new CrudLogger() },
         );
         const interceptorWithFalseOptions = new InterceptorWithFalseOptions();

--- a/src/lib/interceptor/search-request.interceptor.spec.ts
+++ b/src/lib/interceptor/search-request.interceptor.spec.ts
@@ -246,4 +246,31 @@ describe('SearchRequestInterceptor', () => {
             expect(await interceptor.validateBody({ take: 100_000 })).toEqual({ take: 100_000, withDeleted: false });
         });
     });
+
+    it('should be get relation values per each condition', () => {
+        const Interceptor = SearchRequestInterceptor({ entity: {} as typeof BaseEntity }, { relations: [], logger: new CrudLogger() });
+        const interceptor = new Interceptor();
+
+        expect(interceptor.getRelations({ relations: [] })).toEqual([]);
+        expect(interceptor.getRelations({ relations: ['table'] })).toEqual(['table']);
+        expect(interceptor.getRelations({})).toEqual([]);
+
+        const InterceptorWithOptions = SearchRequestInterceptor(
+            { entity: {} as typeof BaseEntity, routes: { readMany: { relations: ['option'] } } },
+            { relations: [], logger: new CrudLogger() },
+        );
+        const interceptorWithOptions = new InterceptorWithOptions();
+        expect(interceptorWithOptions.getRelations({ relations: [] })).toEqual([]);
+        expect(interceptorWithOptions.getRelations({ relations: ['table'] })).toEqual(['table']);
+        expect(interceptorWithOptions.getRelations({})).toEqual(['option']);
+
+        const InterceptorWithFalseOptions = SearchRequestInterceptor(
+            { entity: {} as typeof BaseEntity, routes: { readMany: { relations: false } } },
+            { relations: [], logger: new CrudLogger() },
+        );
+        const interceptorWithFalseOptions = new InterceptorWithFalseOptions();
+        expect(interceptorWithFalseOptions.getRelations({ relations: [] })).toEqual([]);
+        expect(interceptorWithFalseOptions.getRelations({ relations: ['table'] })).toEqual(['table']);
+        expect(interceptorWithFalseOptions.getRelations({})).toEqual([]);
+    });
 });

--- a/src/lib/interceptor/search-request.interceptor.ts
+++ b/src/lib/interceptor/search-request.interceptor.ts
@@ -84,7 +84,7 @@ export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption
                 .setWithDeleted(
                     requestSearchDto.withDeleted ?? crudOptions.routes?.[method]?.softDelete ?? CRUD_POLICY[method].default.softDeleted,
                 )
-                .setRelations(customSearchRequestOptions?.relations ?? factoryOption.relations)
+                .setRelations(this.getRelations(customSearchRequestOptions))
                 .setDeserialize(this.deserialize)
                 .generate();
 
@@ -258,6 +258,19 @@ export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption
                 throw new UnprocessableEntityException(`take must be less than ${limitOfTake}`);
             }
             return takeNumber;
+        }
+
+        getRelations(customSearchRequestOptions: CustomSearchRequestOptions): string[] {
+            if (Array.isArray(customSearchRequestOptions?.relations)) {
+                return customSearchRequestOptions.relations;
+            }
+            if (crudOptions.routes?.[method]?.relations === false) {
+                return [];
+            }
+            if (crudOptions.routes?.[method] && Array.isArray(crudOptions.routes?.[method]?.relations)) {
+                return crudOptions.routes[method].relations;
+            }
+            return factoryOption.relations;
         }
 
         deserialize<T>({ pagination, findOptions, sort }: CrudReadManyRequest<T>): Array<FindOptionsWhere<T>> {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- In Search request, option `relations` does not work.
<img width="564" alt="image" src="https://github.com/woowabros/nestjs-library-crud/assets/1305997/f6dcd03d-4d9a-41e5-b107-18050db46d89">
<img width="459" alt="image" src="https://github.com/woowabros/nestjs-library-crud/assets/1305997/be1f8445-2c90-4c8e-ad79-f3944171e0e3">


Issue Number: N/A

## What is the new behavior?

- `SearchRequestInterceptor` can get the `relations` configuration from CrudOption.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
