### PR TITLE
fix: ts2742

### DIFF
--- a/src/lib/interceptor/create-request.interceptor.spec.ts
+++ b/src/lib/interceptor/create-request.interceptor.spec.ts
@@ -1,4 +1,4 @@
-import { UnprocessableEntityException } from '@nestjs/common';
+import { NestInterceptor, UnprocessableEntityException } from '@nestjs/common';
 import { Type } from 'class-transformer';
 import { IsEmpty, IsNotEmpty, IsNumber, IsString } from 'class-validator';
 import { BaseEntity } from 'typeorm';
@@ -6,6 +6,7 @@ import { BaseEntity } from 'typeorm';
 import { CreateRequestInterceptor } from './create-request.interceptor';
 import { CrudLogger } from '../provider/crud-logger';
 
+type InterceptorType = NestInterceptor<any, any> & { validateBody: (body: unknown) => Promise<unknown> };
 describe('CreateRequestInterceptor', () => {
     class BodyDto extends BaseEntity {
         @IsString({ groups: ['create'] })
@@ -28,7 +29,7 @@ describe('CreateRequestInterceptor', () => {
     it('should intercepts and validate body', async () => {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         const Interceptor = CreateRequestInterceptor({ entity: BodyDto }, { relations: [], logger: new CrudLogger() });
-        const interceptor = new Interceptor();
+        const interceptor = new Interceptor() as InterceptorType;
         expect(await interceptor.validateBody({ col1: 1, col2: '2' })).toEqual({ col1: '1', col2: 2 });
         expect(await interceptor.validateBody({ col1: 1, col2: 2 })).toEqual({ col1: '1', col2: 2 });
 
@@ -40,7 +41,7 @@ describe('CreateRequestInterceptor', () => {
     it('should intercepts and validate body which is array', async () => {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         const Interceptor = CreateRequestInterceptor({ entity: BodyDto }, { relations: [], logger: new CrudLogger() });
-        const interceptor = new Interceptor();
+        const interceptor = new Interceptor() as InterceptorType;
         expect(
             await interceptor.validateBody([
                 { col1: 1, col2: '2' },

--- a/src/lib/interceptor/create-request.interceptor.ts
+++ b/src/lib/interceptor/create-request.interceptor.ts
@@ -1,4 +1,4 @@
-import { CallHandler, ExecutionContext, mixin, NestInterceptor, UnprocessableEntityException } from '@nestjs/common';
+import { CallHandler, ExecutionContext, mixin, NestInterceptor, Type, UnprocessableEntityException } from '@nestjs/common';
 import { ClassConstructor, plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
 import { Request } from 'express';
@@ -9,11 +9,10 @@ import { RequestAbstractInterceptor } from '../abstract';
 import { CRUD_ROUTE_ARGS } from '../constants';
 import { CrudOptions, FactoryOption, CrudCreateRequest, GROUP, Method, EntityType } from '../interface';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface NestedBaseEntityArray extends Array<NestedBaseEntityArray | DeepPartial<EntityType>> {}
 type BaseEntityOrArray = DeepPartial<EntityType> | NestedBaseEntityArray;
 
-export function CreateRequestInterceptor(crudOptions: CrudOptions, factoryOption: FactoryOption) {
+export function CreateRequestInterceptor(crudOptions: CrudOptions, factoryOption: FactoryOption): Type<NestInterceptor> {
     class MixinInterceptor extends RequestAbstractInterceptor implements NestInterceptor {
         constructor() {
             super(factoryOption.logger);

--- a/src/lib/interceptor/delete-request.interceptor.ts
+++ b/src/lib/interceptor/delete-request.interceptor.ts
@@ -1,4 +1,4 @@
-import { CallHandler, ExecutionContext, mixin, NestInterceptor } from '@nestjs/common';
+import { CallHandler, ExecutionContext, mixin, NestInterceptor, Type } from '@nestjs/common';
 import { Request } from 'express';
 import _ from 'lodash';
 import { Observable } from 'rxjs';
@@ -10,7 +10,7 @@ import { CRUD_POLICY } from '../crud.policy';
 import { CrudDeleteOneRequest, CrudOptions, Method, FactoryOption } from '../interface';
 
 const method = Method.DELETE;
-export function DeleteRequestInterceptor(crudOptions: CrudOptions, factoryOption: FactoryOption) {
+export function DeleteRequestInterceptor(crudOptions: CrudOptions, factoryOption: FactoryOption): Type<NestInterceptor> {
     class MixinInterceptor extends RequestAbstractInterceptor implements NestInterceptor {
         constructor() {
             super(factoryOption.logger);

--- a/src/lib/interceptor/read-many-request.interceptor.spec.ts
+++ b/src/lib/interceptor/read-many-request.interceptor.spec.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { CallHandler, UnprocessableEntityException } from '@nestjs/common';
+import { CallHandler, NestInterceptor, UnprocessableEntityException } from '@nestjs/common';
 import { Type } from 'class-transformer';
 import { IsString, IsNotEmpty, IsNumber, IsEmpty } from 'class-validator';
 import { of } from 'rxjs';
 import { BaseEntity } from 'typeorm';
 
+import { CustomReadManyRequestOptions } from './custom-request.interceptor';
 import { ReadManyRequestInterceptor } from './read-many-request.interceptor';
 import { CUSTOM_REQUEST_OPTIONS } from '../constants';
 import { ExecutionContextHost } from '../provider';
@@ -29,10 +30,13 @@ describe('ReadManyRequestInterceptor', () => {
         expect(interceptor).toBeDefined();
         expect(async () => {
             await interceptor.intercept(new ExecutionContextHost([{ [CUSTOM_REQUEST_OPTIONS]: {} }]), handler);
-        }).not.toThrowError();
+        }).not.toThrow();
     });
 
     it('should be able to fields validation from entity columns', async () => {
+        type InterceptorType = NestInterceptor<any, any> & {
+            validateQuery: (query: Record<string, unknown>) => unknown;
+        };
         class QueryDto extends BaseEntity {
             @IsString({ groups: ['readMany'] })
             @IsNotEmpty({ groups: ['readMany'] })
@@ -52,8 +56,8 @@ describe('ReadManyRequestInterceptor', () => {
         }
 
         const Interceptor = ReadManyRequestInterceptor({ entity: QueryDto }, { relations: [], logger: new CrudLogger() });
-        const interceptor = new Interceptor();
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const interceptor = new Interceptor() as InterceptorType;
+
         expect(await interceptor.validateQuery(undefined as any)).toEqual({});
         expect(await interceptor.validateQuery({ col1: 1, col2: '2' })).toEqual({
             col1: '1',
@@ -84,8 +88,11 @@ describe('ReadManyRequestInterceptor', () => {
     });
 
     it('should be get relation values per each condition', () => {
+        type InterceptorType = NestInterceptor<any, any> & {
+            getRelations: (customReadManyRequestOptions: CustomReadManyRequestOptions) => string[];
+        };
         const Interceptor = ReadManyRequestInterceptor({ entity: {} as typeof BaseEntity }, { relations: [], logger: new CrudLogger() });
-        const interceptor = new Interceptor();
+        const interceptor = new Interceptor() as InterceptorType;
 
         expect(interceptor.getRelations({ relations: [] })).toEqual([]);
         expect(interceptor.getRelations({ relations: ['table'] })).toEqual(['table']);
@@ -95,7 +102,7 @@ describe('ReadManyRequestInterceptor', () => {
             { entity: {} as typeof BaseEntity, routes: { readMany: { relations: ['option'] } } },
             { relations: [], logger: new CrudLogger() },
         );
-        const interceptorWithOptions = new InterceptorWithOptions();
+        const interceptorWithOptions = new InterceptorWithOptions() as InterceptorType;
         expect(interceptorWithOptions.getRelations({ relations: [] })).toEqual([]);
         expect(interceptorWithOptions.getRelations({ relations: ['table'] })).toEqual(['table']);
         expect(interceptorWithOptions.getRelations({})).toEqual(['option']);
@@ -104,7 +111,7 @@ describe('ReadManyRequestInterceptor', () => {
             { entity: {} as typeof BaseEntity, routes: { readMany: { relations: false } } },
             { relations: [], logger: new CrudLogger() },
         );
-        const interceptorWithFalseOptions = new InterceptorWithFalseOptions();
+        const interceptorWithFalseOptions = new InterceptorWithFalseOptions() as InterceptorType;
         expect(interceptorWithFalseOptions.getRelations({ relations: [] })).toEqual([]);
         expect(interceptorWithFalseOptions.getRelations({ relations: ['table'] })).toEqual(['table']);
         expect(interceptorWithFalseOptions.getRelations({})).toEqual([]);

--- a/src/lib/interceptor/read-many-request.interceptor.ts
+++ b/src/lib/interceptor/read-many-request.interceptor.ts
@@ -1,4 +1,4 @@
-import { CallHandler, ExecutionContext, mixin, NestInterceptor, UnprocessableEntityException } from '@nestjs/common';
+import { CallHandler, ExecutionContext, mixin, NestInterceptor, Type, UnprocessableEntityException } from '@nestjs/common';
 import { ClassConstructor, plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
 import { Request } from 'express';
@@ -15,7 +15,7 @@ import { PaginationHelper } from '../provider';
 import { CrudReadManyRequest } from '../request';
 
 const method = Method.READ_MANY;
-export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOption: FactoryOption) {
+export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOption: FactoryOption): Type<NestInterceptor> {
     class MixinInterceptor extends RequestAbstractInterceptor implements NestInterceptor {
         constructor() {
             super(factoryOption.logger);

--- a/src/lib/interceptor/read-one-request.interceptor.ts
+++ b/src/lib/interceptor/read-one-request.interceptor.ts
@@ -1,4 +1,4 @@
-import { CallHandler, ExecutionContext, mixin, NestInterceptor, UnprocessableEntityException } from '@nestjs/common';
+import { CallHandler, ExecutionContext, mixin, NestInterceptor, Type, UnprocessableEntityException } from '@nestjs/common';
 import { plainToInstance } from 'class-transformer';
 import { validateSync } from 'class-validator';
 import { Request } from 'express';
@@ -14,7 +14,7 @@ import { RequestFieldsDto } from '../dto/request-fields.dto';
 import { CrudOptions, Method, FactoryOption, CrudReadOneRequest } from '../interface';
 
 const method = Method.READ_ONE;
-export function ReadOneRequestInterceptor(crudOptions: CrudOptions, factoryOption: FactoryOption) {
+export function ReadOneRequestInterceptor(crudOptions: CrudOptions, factoryOption: FactoryOption): Type<NestInterceptor> {
     class MixinInterceptor extends RequestAbstractInterceptor implements NestInterceptor {
         constructor() {
             super(factoryOption.logger);

--- a/src/lib/interceptor/recover-request.interceptor.ts
+++ b/src/lib/interceptor/recover-request.interceptor.ts
@@ -1,4 +1,4 @@
-import { CallHandler, ExecutionContext, mixin, NestInterceptor } from '@nestjs/common';
+import { CallHandler, ExecutionContext, mixin, NestInterceptor, Type } from '@nestjs/common';
 import { Request } from 'express';
 import { Observable } from 'rxjs';
 
@@ -6,7 +6,7 @@ import { RequestAbstractInterceptor } from '../abstract';
 import { CRUD_ROUTE_ARGS, CUSTOM_REQUEST_OPTIONS } from '../constants';
 import { CrudOptions, CrudRecoverRequest, FactoryOption, Method } from '../interface';
 
-export function RecoverRequestInterceptor(crudOptions: CrudOptions, factoryOption: FactoryOption) {
+export function RecoverRequestInterceptor(crudOptions: CrudOptions, factoryOption: FactoryOption): Type<NestInterceptor> {
     class MixinInterceptor extends RequestAbstractInterceptor implements NestInterceptor {
         constructor() {
             super(factoryOption.logger);

--- a/src/lib/interceptor/search-request.interceptor.spec.ts
+++ b/src/lib/interceptor/search-request.interceptor.spec.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { UnprocessableEntityException } from '@nestjs/common';
+import { NestInterceptor, UnprocessableEntityException } from '@nestjs/common';
 import { IsNotEmpty, IsNumber, IsOptional, IsString } from 'class-validator';
 import { BaseEntity } from 'typeorm';
 
+import { CustomSearchRequestOptions } from './custom-request.interceptor';
 import { SearchRequestInterceptor } from './search-request.interceptor';
 import { Sort } from '../interface';
 import { CrudLogger } from '../provider/crud-logger';
@@ -248,8 +249,11 @@ describe('SearchRequestInterceptor', () => {
     });
 
     it('should be get relation values per each condition', () => {
+        type InterceptorType = NestInterceptor<any, any> & {
+            getRelations: (customSearchRequestOptions: CustomSearchRequestOptions) => string[];
+        };
         const Interceptor = SearchRequestInterceptor({ entity: {} as typeof BaseEntity }, { relations: [], logger: new CrudLogger() });
-        const interceptor = new Interceptor();
+        const interceptor = new Interceptor() as InterceptorType;
 
         expect(interceptor.getRelations({ relations: [] })).toEqual([]);
         expect(interceptor.getRelations({ relations: ['table'] })).toEqual(['table']);
@@ -259,7 +263,7 @@ describe('SearchRequestInterceptor', () => {
             { entity: {} as typeof BaseEntity, routes: { search: { relations: ['option'] } } },
             { relations: [], logger: new CrudLogger() },
         );
-        const interceptorWithOptions = new InterceptorWithOptions();
+        const interceptorWithOptions = new InterceptorWithOptions() as InterceptorType;
         expect(interceptorWithOptions.getRelations({ relations: [] })).toEqual([]);
         expect(interceptorWithOptions.getRelations({ relations: ['table'] })).toEqual(['table']);
         expect(interceptorWithOptions.getRelations({})).toEqual(['option']);
@@ -268,7 +272,7 @@ describe('SearchRequestInterceptor', () => {
             { entity: {} as typeof BaseEntity, routes: { search: { relations: false } } },
             { relations: [], logger: new CrudLogger() },
         );
-        const interceptorWithFalseOptions = new InterceptorWithFalseOptions();
+        const interceptorWithFalseOptions = new InterceptorWithFalseOptions() as InterceptorType;
         expect(interceptorWithFalseOptions.getRelations({ relations: [] })).toEqual([]);
         expect(interceptorWithFalseOptions.getRelations({ relations: ['table'] })).toEqual(['table']);
         expect(interceptorWithFalseOptions.getRelations({})).toEqual([]);

--- a/src/lib/interceptor/search-request.interceptor.ts
+++ b/src/lib/interceptor/search-request.interceptor.ts
@@ -1,4 +1,4 @@
-import { CallHandler, ExecutionContext, mixin, NestInterceptor, UnprocessableEntityException } from '@nestjs/common';
+import { CallHandler, ExecutionContext, mixin, NestInterceptor, Type, UnprocessableEntityException } from '@nestjs/common';
 import { plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
 import { Request } from 'express';
@@ -18,7 +18,7 @@ import { PaginationHelper, TypeOrmQueryBuilderHelper } from '../provider';
 import { CrudReadManyRequest } from '../request';
 
 const method = Method.SEARCH;
-export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption: FactoryOption) {
+export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption: FactoryOption): Type<NestInterceptor> {
     class MixinInterceptor extends RequestAbstractInterceptor implements NestInterceptor {
         constructor() {
             super(factoryOption.logger);

--- a/src/lib/interceptor/update-request.interceptor.spec.ts
+++ b/src/lib/interceptor/update-request.interceptor.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-classes-per-file */
 /* eslint-disable @typescript-eslint/naming-convention */
-import { UnprocessableEntityException } from '@nestjs/common';
+import { NestInterceptor, UnprocessableEntityException } from '@nestjs/common';
 import { Type } from 'class-transformer';
 import { IsEmpty, IsNotEmpty, IsNumber, IsString } from 'class-validator';
 import { BaseEntity } from 'typeorm';
@@ -8,6 +8,7 @@ import { BaseEntity } from 'typeorm';
 import { UpdateRequestInterceptor } from './update-request.interceptor';
 import { CrudLogger } from '../provider/crud-logger';
 
+type InterceptorType = NestInterceptor<any, any> & { validateBody: (body: unknown) => Promise<unknown> };
 describe('UpdateRequestInterceptor', () => {
     it('should be not changed value of primary key', async () => {
         class BodyDto extends BaseEntity {
@@ -32,9 +33,9 @@ describe('UpdateRequestInterceptor', () => {
             { entity: BodyDto },
             { primaryKeys: [{ name: 'col1', type: 'string' }], relations: [], logger: new CrudLogger() },
         );
-        const interceptor = new Interceptor();
+        const interceptor = new Interceptor() as InterceptorType;
 
-        await expect(interceptor.validateBody({ col1: 1, col2: 2 })).rejects.toThrowError(
+        await expect(interceptor.validateBody({ col1: 1, col2: 2 })).rejects.toThrow(
             new UnprocessableEntityException('Cannot changed value of primary key'),
         );
         expect(await interceptor.validateBody({ col2: 2 })).toEqual({ col2: 2 });
@@ -58,7 +59,7 @@ describe('UpdateRequestInterceptor', () => {
             col3: number;
         }
         const Interceptor = UpdateRequestInterceptor({ entity: BodyDto }, { primaryKeys: [], relations: [], logger: new CrudLogger() });
-        const interceptor = new Interceptor();
+        const interceptor = new Interceptor() as InterceptorType;
         expect(await interceptor.validateBody({ col1: 1, col2: '2' })).toEqual({
             col1: '1',
             col2: 2,
@@ -79,7 +80,7 @@ describe('UpdateRequestInterceptor', () => {
             { entity: {} as typeof BaseEntity },
             { primaryKeys: [], relations: [], logger: new CrudLogger() },
         );
-        const interceptor = new Interceptor();
+        const interceptor = new Interceptor() as InterceptorType;
 
         await expect(interceptor.validateBody(null)).rejects.toThrow(UnprocessableEntityException);
         await expect(interceptor.validateBody(undefined)).rejects.toThrow(UnprocessableEntityException);
@@ -90,7 +91,7 @@ describe('UpdateRequestInterceptor', () => {
             { entity: {} as typeof BaseEntity },
             { primaryKeys: [], relations: [], logger: new CrudLogger() },
         );
-        const interceptor = new Interceptor();
+        const interceptor = new Interceptor() as InterceptorType;
 
         await expect(interceptor.validateBody(1)).rejects.toThrow(UnprocessableEntityException);
         await expect(interceptor.validateBody('')).rejects.toThrow(UnprocessableEntityException);

--- a/src/lib/interceptor/update-request.interceptor.ts
+++ b/src/lib/interceptor/update-request.interceptor.ts
@@ -1,4 +1,4 @@
-import { CallHandler, ExecutionContext, mixin, NestInterceptor, UnprocessableEntityException } from '@nestjs/common';
+import { CallHandler, ExecutionContext, mixin, NestInterceptor, Type, UnprocessableEntityException } from '@nestjs/common';
 import { ClassConstructor, plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
 import { Request } from 'express';
@@ -9,7 +9,7 @@ import { RequestAbstractInterceptor } from '../abstract';
 import { CRUD_ROUTE_ARGS } from '../constants';
 import { CrudOptions, CrudUpdateOneRequest, EntityType, FactoryOption, GROUP, Method } from '../interface';
 
-export function UpdateRequestInterceptor(crudOptions: CrudOptions, factoryOption: FactoryOption) {
+export function UpdateRequestInterceptor(crudOptions: CrudOptions, factoryOption: FactoryOption): Type<NestInterceptor> {
     class MixinInterceptor extends RequestAbstractInterceptor implements NestInterceptor {
         constructor() {
             super(factoryOption.logger);

--- a/src/lib/interceptor/upsert-request.interceptor.spec.ts
+++ b/src/lib/interceptor/upsert-request.interceptor.spec.ts
@@ -1,6 +1,6 @@
-/* eslint-disable max-classes-per-file */
 /* eslint-disable @typescript-eslint/naming-convention */
-import { UnprocessableEntityException } from '@nestjs/common';
+/* eslint-disable max-classes-per-file */
+import { NestInterceptor, UnprocessableEntityException } from '@nestjs/common';
 import { Type } from 'class-transformer';
 import { IsEmpty, IsNotEmpty, IsNumber, IsString } from 'class-validator';
 import { BaseEntity } from 'typeorm';
@@ -8,6 +8,7 @@ import { BaseEntity } from 'typeorm';
 import { UpsertRequestInterceptor } from './upsert-request.interceptor';
 import { CrudLogger } from '../provider/crud-logger';
 
+type InterceptorType = NestInterceptor<any, any> & { validateBody: (body: unknown) => Promise<unknown> };
 describe('UpsertRequestInterceptor', () => {
     it('should be not include value of primary key', async () => {
         class BodyDto extends BaseEntity {
@@ -32,9 +33,9 @@ describe('UpsertRequestInterceptor', () => {
             { entity: BodyDto },
             { primaryKeys: [{ name: 'col1', type: 'string' }], relations: [], logger: new CrudLogger() },
         );
-        const interceptor = new Interceptor();
+        const interceptor = new Interceptor() as InterceptorType;
 
-        await expect(interceptor.validateBody({ col1: 1, col2: 2 })).rejects.toThrowError(
+        await expect(interceptor.validateBody({ col1: 1, col2: 2 })).rejects.toThrow(
             new UnprocessableEntityException('Cannot include value of primary key'),
         );
         expect(await interceptor.validateBody({ col2: 2 })).toEqual({ col2: 2 });
@@ -59,7 +60,7 @@ describe('UpsertRequestInterceptor', () => {
             col3: number;
         }
         const Interceptor = UpsertRequestInterceptor({ entity: BodyDto }, { primaryKeys: [], relations: [], logger: new CrudLogger() });
-        const interceptor = new Interceptor();
+        const interceptor = new Interceptor() as InterceptorType;
         expect(await interceptor.validateBody({ col1: 1, col2: '2' })).toEqual({
             col1: '1',
             col2: 2,
@@ -80,7 +81,7 @@ describe('UpsertRequestInterceptor', () => {
             { entity: {} as typeof BaseEntity },
             { primaryKeys: [], relations: [], logger: new CrudLogger() },
         );
-        const interceptor = new Interceptor();
+        const interceptor = new Interceptor() as InterceptorType;
 
         await expect(interceptor.validateBody(null)).rejects.toThrow(UnprocessableEntityException);
         await expect(interceptor.validateBody(undefined)).rejects.toThrow(UnprocessableEntityException);
@@ -91,7 +92,7 @@ describe('UpsertRequestInterceptor', () => {
             { entity: {} as typeof BaseEntity },
             { primaryKeys: [], relations: [], logger: new CrudLogger() },
         );
-        const interceptor = new Interceptor();
+        const interceptor = new Interceptor() as InterceptorType;
 
         await expect(interceptor.validateBody(1)).rejects.toThrow(UnprocessableEntityException);
         await expect(interceptor.validateBody('')).rejects.toThrow(UnprocessableEntityException);

--- a/src/lib/interceptor/upsert-request.interceptor.ts
+++ b/src/lib/interceptor/upsert-request.interceptor.ts
@@ -1,4 +1,12 @@
-import { CallHandler, ConflictException, ExecutionContext, mixin, NestInterceptor, UnprocessableEntityException } from '@nestjs/common';
+import {
+    CallHandler,
+    ConflictException,
+    ExecutionContext,
+    mixin,
+    NestInterceptor,
+    Type,
+    UnprocessableEntityException,
+} from '@nestjs/common';
 import { ClassConstructor, plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
 import { Request } from 'express';
@@ -9,7 +17,7 @@ import { RequestAbstractInterceptor } from '../abstract';
 import { CRUD_ROUTE_ARGS } from '../constants';
 import { CrudOptions, CrudUpsertRequest, EntityType, FactoryOption, GROUP, Method } from '../interface';
 
-export function UpsertRequestInterceptor(crudOptions: CrudOptions, factoryOption: FactoryOption) {
+export function UpsertRequestInterceptor(crudOptions: CrudOptions, factoryOption: FactoryOption): Type<NestInterceptor> {
     class MixinInterceptor extends RequestAbstractInterceptor implements NestInterceptor {
         constructor() {
             super(factoryOption.logger);

--- a/src/lib/provider/pagination.helper.spec.ts
+++ b/src/lib/provider/pagination.helper.spec.ts
@@ -45,9 +45,7 @@ describe('Pagination Helper', () => {
             _isNext: false,
         });
 
-        expect(() => PaginationHelper.getPaginationRequest(PaginationType.CURSOR, { nextCursor: 3 })).toThrowError(
-            UnprocessableEntityException,
-        );
+        expect(() => PaginationHelper.getPaginationRequest(PaginationType.CURSOR, { nextCursor: 3 })).toThrow(UnprocessableEntityException);
 
         expect(PaginationHelper.getPaginationRequest(PaginationType.OFFSET, undefined as any)).toEqual({
             type: 'offset',
@@ -57,13 +55,9 @@ describe('Pagination Helper', () => {
             _isNext: false,
         });
 
-        expect(() => PaginationHelper.getPaginationRequest(PaginationType.OFFSET, { nextCursor: 3 })).toThrowError(
-            UnprocessableEntityException,
-        );
+        expect(() => PaginationHelper.getPaginationRequest(PaginationType.OFFSET, { nextCursor: 3 })).toThrow(UnprocessableEntityException);
 
-        expect(() => PaginationHelper.getPaginationRequest(PaginationType.OFFSET, { limit: 200 })).toThrowError(
-            UnprocessableEntityException,
-        );
+        expect(() => PaginationHelper.getPaginationRequest(PaginationType.OFFSET, { limit: 200 })).toThrow(UnprocessableEntityException);
     });
 
     it('should be return empty object when nextCursor is undefined', () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [x] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

```
src/lib/interceptor/upsert-request.interceptor.ts:12:17 - error TS2742: The inferred type of 'UpsertRequestInterceptor' cannot be named without a reference to 'express-serve-static-core/node_modules/@types/qs'. This is likely not portable. A type annotation is necessary.

12 export function UpsertRequestInterceptor(crudOptions: CrudOptions, factoryOption: FactoryOption) {
```

deprecated `toThrowError` 
```
        /**
         * If you want to test that a specific error is thrown inside a function.
         *
         * @deprecated in favor of `toThrow`
         */
        toThrowError(error?: string | Constructable | RegExp | Error): R;
```

## What is the new behavior?

resolved typescript error

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
