### PR TITLE
feat: can be used without define entity name

### DIFF
--- a/spec/entity-inheritance/child-entity-noname.spec.ts
+++ b/spec/entity-inheritance/child-entity-noname.spec.ts
@@ -1,0 +1,171 @@
+/* eslint-disable max-classes-per-file */
+import { Controller, HttpStatus, INestApplication, Injectable, Module } from '@nestjs/common';
+import { TestingModule, Test } from '@nestjs/testing';
+import { InjectRepository, TypeOrmModule } from '@nestjs/typeorm';
+import { Type } from 'class-transformer';
+import { IsNumber, IsOptional, IsString } from 'class-validator';
+import request from 'supertest';
+import { Entity, TableInheritance, PrimaryGeneratedColumn, Column, ChildEntity, Repository } from 'typeorm';
+
+import { Crud } from '../../src/lib/crud.decorator';
+import { CrudService } from '../../src/lib/crud.service';
+import { CrudController, GROUP, Method } from '../../src/lib/interface';
+import { TestHelper } from '../test.helper';
+
+@Entity()
+@TableInheritance({ column: { type: 'varchar', name: 'type' } })
+class ContentEntity {
+    @PrimaryGeneratedColumn()
+    @IsNumber({}, { groups: [GROUP.PARAMS] })
+    @Type(() => Number)
+    id: number;
+
+    @Column()
+    @IsString({ always: true })
+    @IsOptional({ always: true })
+    title: string;
+
+    @Column()
+    @IsString({ always: true })
+    @IsOptional({ always: true })
+    description: string;
+}
+
+@ChildEntity()
+class PhotoEntity extends ContentEntity {
+    @Column()
+    @IsString({ always: true })
+    @IsOptional({ always: true })
+    size: string;
+}
+
+@Injectable()
+class PhotoService extends CrudService<PhotoEntity> {
+    constructor(@InjectRepository(PhotoEntity) repository: Repository<PhotoEntity>) {
+        super(repository);
+    }
+}
+
+@Crud({
+    entity: PhotoEntity,
+    routes: { [Method.DELETE]: { softDelete: false } },
+})
+@Controller('photo')
+class PhotoController implements CrudController<PhotoEntity> {
+    constructor(public readonly crudService: PhotoService) {}
+}
+
+@ChildEntity()
+class QuestionEntity extends ContentEntity {
+    @Column()
+    @Type(() => Number)
+    @IsNumber({}, { always: true })
+    @IsOptional({ always: true })
+    answersCount: number;
+}
+@Injectable()
+class QuestionService extends CrudService<QuestionEntity> {
+    constructor(@InjectRepository(QuestionEntity) repository: Repository<QuestionEntity>) {
+        super(repository);
+    }
+}
+
+@Crud({
+    entity: QuestionEntity,
+    routes: { [Method.DELETE]: { softDelete: false } },
+})
+@Controller('question')
+class QuestionController implements CrudController<QuestionEntity> {
+    constructor(public readonly crudService: QuestionService) {}
+}
+
+@Module({
+    imports: [TypeOrmModule.forFeature([ContentEntity, PhotoEntity, QuestionEntity])],
+    controllers: [PhotoController, QuestionController],
+    providers: [PhotoService, QuestionService],
+})
+class ContentModule {}
+
+describe('Child Entity (no-named)', () => {
+    let app: INestApplication;
+    let photoService: PhotoService;
+    let questionService: QuestionService;
+
+    beforeAll(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [ContentModule, TestHelper.getTypeOrmPgsqlModule([ContentEntity, PhotoEntity, QuestionEntity])],
+        }).compile();
+        app = moduleFixture.createNestApplication();
+
+        photoService = moduleFixture.get<PhotoService>(PhotoService);
+        questionService = moduleFixture.get<QuestionService>(QuestionService);
+        await app.init();
+    });
+
+    afterAll(async () => {
+        await app?.close();
+    });
+
+    it('should be defined', () => {
+        expect(app).toBeDefined();
+    });
+
+    it('should be used PhotoEntity', async () => {
+        await photoService.repository.delete({});
+        const title = `Tester-${Date.now()}`;
+        const { body: created } = await request(app.getHttpServer())
+            .post('/photo')
+            .send({ title, description: 'Photo Test', size: '100px' })
+            .expect(HttpStatus.CREATED);
+        expect(created.title).toEqual(title);
+        expect(created.id).toBeDefined();
+        expect(created.size).toEqual('100px');
+
+        const { body: readOne } = await request(app.getHttpServer()).get(`/photo/${created.id}`).expect(HttpStatus.OK);
+        expect(readOne.title).toEqual(title);
+
+        const { body: readMany } = await request(app.getHttpServer()).get('/photo').expect(HttpStatus.OK);
+        expect(readMany.data).toHaveLength(1);
+        expect(readMany.data[0].title).toEqual(title);
+        expect(readMany.metadata.total).toEqual(1);
+
+        const { body: updated } = await request(app.getHttpServer())
+            .patch(`/photo/${created.id}`)
+            .send({ title: 'updated' })
+            .expect(HttpStatus.OK);
+        expect(updated.title).toEqual('updated');
+
+        await request(app.getHttpServer()).delete(`/photo/${created.id}`).expect(HttpStatus.OK);
+        await request(app.getHttpServer()).get(`/photo/${created.id}`).expect(HttpStatus.NOT_FOUND);
+    });
+
+    it('should be used QuestionEntity', async () => {
+        await questionService.repository.delete({});
+        const title = `Tester-${Date.now()}`;
+        const { body: created } = await request(app.getHttpServer())
+            .post('/question')
+            .send({ title, description: 'Question Test', answersCount: 10 })
+            .expect(HttpStatus.CREATED);
+        expect(created.title).toEqual(title);
+        expect(created.id).toBeDefined();
+        expect(created.size).not.toBeDefined();
+        expect(created.answersCount).toEqual(10);
+
+        const { body: readOne } = await request(app.getHttpServer()).get(`/question/${created.id}`).expect(HttpStatus.OK);
+        expect(readOne.title).toEqual(title);
+
+        const { body: readMany } = await request(app.getHttpServer()).get('/question').expect(HttpStatus.OK);
+        expect(readMany.data).toHaveLength(1);
+        expect(readMany.data[0].title).toEqual(title);
+        expect(readMany.metadata.total).toEqual(1);
+
+        const { body: updated } = await request(app.getHttpServer())
+            .patch(`/question/${created.id}`)
+            .send({ title: 'updated' })
+            .expect(HttpStatus.OK);
+        expect(updated.title).toEqual('updated');
+
+        await request(app.getHttpServer()).delete(`/question/${created.id}`).expect(HttpStatus.OK);
+        await request(app.getHttpServer()).get(`/question/${created.id}`).expect(HttpStatus.NOT_FOUND);
+    });
+});

--- a/spec/general-entity/without-name.spec.ts
+++ b/spec/general-entity/without-name.spec.ts
@@ -1,0 +1,119 @@
+/* eslint-disable max-classes-per-file */
+import { HttpStatus, INestApplication } from '@nestjs/common';
+import { Controller, Injectable, Module } from '@nestjs/common';
+import { ApiHideProperty, ApiProperty } from '@nestjs/swagger';
+import { Test, TestingModule } from '@nestjs/testing';
+import { InjectRepository, TypeOrmModule } from '@nestjs/typeorm';
+import { Type } from 'class-transformer';
+import { IsNumber, IsOptional, IsString } from 'class-validator';
+import request from 'supertest';
+import { Entity, Repository, Column, DeleteDateColumn, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+import { Crud } from '../../src/lib/crud.decorator';
+import { CrudService } from '../../src/lib/crud.service';
+import { CrudController, GROUP } from '../../src/lib/interface';
+import { TestHelper } from '../test.helper';
+
+@Entity()
+class NoNamedEntity {
+    @PrimaryGeneratedColumn({ type: 'bigint' })
+    @ApiProperty({ description: 'ID' })
+    @IsNumber({}, { groups: [GROUP.PARAMS] })
+    @Type(() => Number)
+    id: number;
+
+    @Column()
+    @ApiProperty({ description: 'Name' })
+    @IsString({ always: true })
+    @IsOptional({ groups: [GROUP.CREATE, GROUP.UPDATE, GROUP.READ_MANY, GROUP.UPSERT, GROUP.SEARCH] })
+    name: string;
+
+    @Column({ nullable: true })
+    @ApiProperty({ description: 'Description' })
+    @IsString({ always: true })
+    @IsOptional({ always: true })
+    description: string;
+
+    @CreateDateColumn()
+    @ApiProperty({ description: 'Created At' })
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    @ApiProperty({ description: 'Last Modified At' })
+    updatedAt: Date;
+
+    @DeleteDateColumn()
+    @ApiHideProperty()
+    deletedAt?: Date;
+}
+
+@Injectable()
+class TestService extends CrudService<NoNamedEntity> {
+    constructor(@InjectRepository(NoNamedEntity) repository: Repository<NoNamedEntity>) {
+        super(repository);
+    }
+}
+
+@Crud({
+    entity: NoNamedEntity,
+})
+@Controller('no-named')
+class TestController implements CrudController<NoNamedEntity> {
+    constructor(public readonly crudService: TestService) {}
+}
+
+@Module({
+    imports: [TypeOrmModule.forFeature([NoNamedEntity])],
+    controllers: [TestController],
+    providers: [TestService],
+})
+class TestModule {}
+
+describe('Should be used even if it does not defined name', () => {
+    let app: INestApplication;
+    let service: TestService;
+
+    beforeAll(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [TestModule, TestHelper.getTypeOrmPgsqlModule([NoNamedEntity])],
+        }).compile();
+        app = moduleFixture.createNestApplication();
+
+        service = app.get<TestService>(TestService);
+        await app.init();
+    });
+
+    afterAll(async () => {
+        await app?.close();
+    });
+
+    it('should be defined', () => {
+        expect(app).toBeDefined();
+    });
+
+    it('should be used NoNamedEntity', async () => {
+        await service.repository.delete({});
+
+        const name = `Tester-${Date.now()}`;
+        const { body: created } = await request(app.getHttpServer()).post('/no-named').send({ name }).expect(HttpStatus.CREATED);
+        expect(created.name).toEqual(name);
+        expect(created.id).toBeDefined();
+
+        const { body: readOne } = await request(app.getHttpServer()).get(`/no-named/${created.id}`).expect(HttpStatus.OK);
+        expect(readOne.name).toEqual(name);
+
+        const { body: readMany } = await request(app.getHttpServer()).get('/no-named').expect(HttpStatus.OK);
+        expect(readMany.data).toHaveLength(1);
+        expect(readMany.data[0].name).toEqual(name);
+        expect(readMany.metadata.total).toEqual(1);
+
+        const { body: updated } = await request(app.getHttpServer())
+            .patch(`/no-named/${created.id}`)
+            .send({ name: 'updated' })
+            .expect(HttpStatus.OK);
+        expect(updated.name).toEqual('updated');
+
+        await request(app.getHttpServer()).delete(`/no-named/${created.id}`).expect(HttpStatus.OK);
+        await request(app.getHttpServer()).get(`/no-named/${created.id}`).expect(HttpStatus.NOT_FOUND);
+    });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/woowabros/nestjs-library-crud/issues/383

Defining the `entity name is required`.

## What is the new behavior?

It can be used even `without defining an entity name`.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
