### PR TITLE
feat: override swagger body

### DIFF
--- a/spec/exclude-swagger/exclude-swagger.spec.ts
+++ b/spec/exclude-swagger/exclude-swagger.spec.ts
@@ -101,14 +101,14 @@ describe('exclude swagger by route', () => {
                 content: {
                     'application/json': {
                         schema: {
-                            $ref: '#/components/schemas/CreateBaseBodyDto',
+                            $ref: '#/components/schemas/PickTypeClass',
                             anyOf: [
                                 {
-                                    $ref: '#/components/schemas/CreateBaseBodyDto',
+                                    $ref: '#/components/schemas/PickTypeClass',
                                 },
                                 {
                                     items: {
-                                        $ref: '#/components/schemas/CreateBaseBodyDto',
+                                        $ref: '#/components/schemas/PickTypeClass',
                                     },
                                     type: 'array',
                                 },

--- a/spec/swagger-decorator/swagger-decorator.controller.ts
+++ b/spec/swagger-decorator/swagger-decorator.controller.ts
@@ -2,6 +2,7 @@ import { Controller } from '@nestjs/common';
 import { ApiParam } from '@nestjs/swagger';
 
 import { ParamsRequestInterceptor } from './params.request.interceptor';
+import { UpdateRequestDto } from './update-request.dto';
 import { Crud } from '../../src/lib/crud.decorator';
 import { CrudController } from '../../src/lib/interface';
 import { BaseEntity } from '../base/base.entity';
@@ -21,6 +22,11 @@ import { BaseService } from '../base/base.service';
         create: {
             interceptors: [ParamsRequestInterceptor],
             decorators: [ApiParam({ name: 'key', required: true })],
+        },
+        update: {
+            swagger: {
+                body: UpdateRequestDto,
+            },
         },
     },
 })

--- a/spec/swagger-decorator/update-request.dto.ts
+++ b/spec/swagger-decorator/update-request.dto.ts
@@ -1,0 +1,8 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+import { BaseEntity } from '../base/base.entity';
+
+export class UpdateRequestDto implements Partial<BaseEntity> {
+    @ApiPropertyOptional({ description: 'optional name', type: String })
+    name: string;
+}

--- a/src/lib/crud.route.factory.ts
+++ b/src/lib/crud.route.factory.ts
@@ -330,6 +330,10 @@ export class CrudRouteFactory {
         }
         if (CRUD_POLICY[method].useBody) {
             const bodyType = (() => {
+                const customBody = this.crudOptions.routes?.[method]?.swagger?.body;
+                if (customBody != null) {
+                    return customBody;
+                }
                 if (method === Method.SEARCH) {
                     return RequestSearchDto;
                 }

--- a/src/lib/interface/decorator-option.interface.ts
+++ b/src/lib/interface/decorator-option.interface.ts
@@ -24,6 +24,10 @@ interface RouteBaseOption {
          * Configures the Swagger documentation for the route's response
          */
         response?: Type<unknown>;
+        /**
+         * Configures the Swagger documentation for the route's request body
+         */
+        body?: Type<unknown>;
     };
     /**
      * Configures the keys of entity to exclude from the route's response


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

My plan was that the `@ApiBody decorator` would be used to override the Swagger body.

```
@Crud({
  entity: ReferenceCodeEntity,
  routes: {
    [Method.UPDATE]: {
      decorators: [
        ApiBody({
          type: UpdateReferenceCodeRequestDto,
        }),
      ],
    },
  },
})
```

I found that the other Swagger Decorators work as planned, but the ApiBody does not.


## What is the new behavior?

I provide new option to override Swagger Body.


```
@Crud({
  entity: ReferenceCodeEntity,
  routes: {
    [Method.UPDATE]: {
      swagger: {
        body: UpdateReferenceCodeRequestDto,
      },
    },
  },
})
```

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
