### PR TITLE
feat: updated to swagger docs reflect the paginationType for search

### DIFF
--- a/src/lib/crud.policy.ts
+++ b/src/lib/crud.policy.ts
@@ -27,7 +27,7 @@ type MethodPolicy<T extends Method> = {
     uriParameter: (crudOptions: CrudOptions, primaryKeys?: PrimaryKey[]) => { path: string; params: string[] };
     swagger: {
         operationMetadata: (tableName: string) => { summary: string; description: string };
-        responseMetadata: (opts: { type: Type<unknown>; tableName: string; paginationType: PaginationType }) => {
+        responseMetadata: (opts: { type: Type<unknown>; tableName: string; paginationType?: PaginationType }) => {
             [key in HttpStatus]?: { description: string; type?: Type<unknown>; schema?: unknown };
         };
     };
@@ -108,7 +108,7 @@ export const CRUD_POLICY: CrudMethodPolicy = {
                 summary: `Search from '${capitalizeFirstLetter(tableName)}' Table`,
                 description: `Fetch multiple entities in '${capitalizeFirstLetter(tableName)}' Table via custom query in body`,
             }),
-            responseMetadata: ({ type, tableName }) => ({
+            responseMetadata: ({ type, tableName, paginationType }) => ({
                 [HttpStatus.OK]: {
                     description: `Fetch multiple entities from '${capitalizeFirstLetter(tableName)}' table`,
                     schema: {
@@ -119,6 +119,10 @@ export const CRUD_POLICY: CrudMethodPolicy = {
                                 items: {
                                     $ref: `#/components/schemas/${type.name}`,
                                 },
+                            },
+                            metadata: paginationType && {
+                                type: 'object',
+                                properties: metaProperties(paginationType),
                             },
                         },
                     },
@@ -162,7 +166,7 @@ export const CRUD_POLICY: CrudMethodPolicy = {
                                                 $ref: `#/components/schemas/${type.name}`,
                                             },
                                         },
-                                        metadata: {
+                                        metadata: paginationType && {
                                             type: 'object',
                                             properties: metaProperties(paginationType),
                                         },

--- a/src/lib/crud.route.factory.spec.ts
+++ b/src/lib/crud.route.factory.spec.ts
@@ -11,16 +11,27 @@ describe('CrudRouteFactory', () => {
         expect(() => new CrudRouteFactory({ prototype: {} }, { entity: {} as typeof BaseEntity })).toThrow(Error);
     });
 
-    it('should be checked paginationType', () => {
-        expect(
-            () =>
-                new CrudRouteFactory(
-                    { prototype: {} },
-                    {
-                        entity: TestEntity,
-                        routes: { readMany: { paginationType: 'wrong' as unknown as PaginationType } },
-                    },
-                ),
+    it('should be checked paginationType of readMany route', () => {
+        expect(() =>
+            new CrudRouteFactory(
+                { prototype: {} },
+                {
+                    entity: TestEntity,
+                    routes: { readMany: { paginationType: 'wrong' as unknown as PaginationType } },
+                },
+            ).init(),
+        ).toThrow(TypeError);
+    });
+
+    it('should be checked paginationType of search route', () => {
+        expect(() =>
+            new CrudRouteFactory(
+                { prototype: {} },
+                {
+                    entity: TestEntity,
+                    routes: { search: { paginationType: 'wrong' as unknown as PaginationType } },
+                },
+            ).init(),
         ).toThrow(TypeError);
     });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In auto-generated swagger docs, paginationType is not reflected for the search route. 
In the case of readMany, the type of the query parameter and the response body varies depending on the paginationType.

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

Now paginationType is also reflected in the document for search route.

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
