### PR TITLE
feat: added paginationKeys as @Crud options in search and readMany

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -227,6 +227,7 @@ interface ReadManyOptions {
     numberOfTake?: number;
     relations?: false | string[];
     softDelete?: boolean;
+    paginationKeys?: string[];
 }
 ```
 
@@ -241,6 +242,7 @@ interface SearchOptions {
     limitOfTake?: number;
     relations?: false | string[];
     softDelete?: boolean;
+    paginationKeys?: string[];
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ interface ReadManyOptions {
     numberOfTake?: number;
     relations?: false | string[];
     softDelete?: boolean;
+    paginationKeys?: string[];
 }
 ```
 
@@ -225,6 +226,7 @@ interface SearchOptions {
     limitOfTake?: number;
     relations?: false | string[];
     softDelete?: boolean;
+    paginationKeys?: string[];
 }
 ```
 

--- a/spec/logging/logging.spec.ts
+++ b/spec/logging/logging.spec.ts
@@ -79,7 +79,7 @@ describe('Logging', () => {
         expect(loggerSpy).toHaveBeenNthCalledWith(
             2,
             JSON.stringify({
-                _primaryKeys: [{ name: 'col1', isPrimary: true }],
+                _paginationKeys: ['col1'],
                 _findOptions: {
                     where: {},
                     take: 20,

--- a/spec/pagination/view-entity-pagination.module.ts
+++ b/spec/pagination/view-entity-pagination.module.ts
@@ -1,0 +1,75 @@
+/* eslint-disable max-classes-per-file */
+import { Controller, forwardRef, Module } from '@nestjs/common';
+import { InjectRepository, TypeOrmModule } from '@nestjs/typeorm';
+import { Type } from 'class-transformer';
+import { Repository, ViewColumn, ViewEntity } from 'typeorm';
+
+import { Crud, CrudController, CrudOptions, CrudService, Method, PaginationType } from '../../src';
+import { BaseEntity } from '../base/base.entity';
+import { BaseService } from '../base/base.service';
+import { TestHelper } from '../test.helper';
+
+@ViewEntity('base_view', {
+    expression: `
+        SELECT DISTINCT id, name, type % 2 as category FROM base
+    `,
+})
+export class BaseView {
+    @ViewColumn()
+    @Type(() => String)
+    id: string;
+
+    @ViewColumn()
+    @Type(() => String)
+    name: string;
+
+    @ViewColumn()
+    @Type(() => Number)
+    category: number;
+}
+
+export class BaseViewService extends CrudService<BaseView> {
+    constructor(@InjectRepository(BaseView) repository: Repository<BaseView>) {
+        super(repository);
+    }
+}
+
+export function ViewEntityPaginationModule(crudOptions?: Record<PaginationType, CrudOptions['routes']>) {
+    function cursorController() {
+        @Crud({
+            entity: BaseView,
+            routes: crudOptions?.[PaginationType.CURSOR],
+            only: [Method.READ_MANY, Method.SEARCH],
+            logging: true,
+        })
+        @Controller(`${PaginationType.CURSOR}`)
+        class CursorController implements CrudController<BaseView> {
+            constructor(public readonly crudService: BaseViewService) {}
+        }
+        return CursorController;
+    }
+
+    function offsetController() {
+        @Crud({ entity: BaseView, routes: crudOptions?.[PaginationType.OFFSET], only: [Method.READ_MANY, Method.SEARCH], logging: true })
+        @Controller(`${PaginationType.OFFSET}`)
+        class OffsetController implements CrudController<BaseView> {
+            constructor(public readonly crudService: BaseViewService) {}
+        }
+        return OffsetController;
+    }
+
+    function getModule() {
+        @Module({
+            imports: [
+                forwardRef(() => TestHelper.getTypeOrmMysqlModule([BaseEntity, BaseView])),
+                TypeOrmModule.forFeature([BaseEntity, BaseView]),
+            ],
+            controllers: [cursorController(), offsetController()],
+            providers: [BaseViewService, BaseService],
+        })
+        class BaseViewModule {}
+        return BaseViewModule;
+    }
+
+    return getModule();
+}

--- a/spec/pagination/with-pagination-keys.spec.ts
+++ b/spec/pagination/with-pagination-keys.spec.ts
@@ -1,0 +1,204 @@
+import { ConsoleLogger, HttpStatus, INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+
+import { ViewEntityPaginationModule } from './view-entity-pagination.module';
+import { PaginationType } from '../../src';
+import { BaseService } from '../base/base.service';
+import { TestHelper } from '../test.helper';
+
+describe('Pagination with paginationKeys option', () => {
+    let app: INestApplication;
+    let baseEntityService: BaseService;
+    const totalCount = 100;
+    const defaultLimit = 20;
+
+    beforeAll(async () => {
+        const logger = new ConsoleLogger();
+        logger.setLogLevels(['error']);
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [
+                ViewEntityPaginationModule({
+                    cursor: {
+                        readMany: { paginationType: 'cursor', numberOfTake: defaultLimit, paginationKeys: ['name'] },
+                        search: { paginationType: 'cursor', numberOfTake: defaultLimit, paginationKeys: ['name'] },
+                    },
+                    offset: {
+                        readMany: { paginationType: 'offset', numberOfTake: defaultLimit, paginationKeys: ['name'] },
+                        search: { paginationType: 'offset', numberOfTake: defaultLimit, paginationKeys: ['name'] },
+                    },
+                }),
+            ],
+        })
+            .setLogger(logger)
+            .compile();
+        app = moduleFixture.createNestApplication();
+
+        baseEntityService = moduleFixture.get<BaseService>(BaseService);
+        await app.init();
+    });
+
+    beforeEach(async () => {
+        await baseEntityService.repository.delete({});
+        await baseEntityService.repository.save(
+            Array.from({ length: totalCount }, (_, index) => index).map((number) => ({
+                name: `name-${(number + 1).toString().padStart(3, '0')}`,
+                type: number,
+            })),
+        );
+    });
+
+    afterAll(async () => {
+        await TestHelper.dropTypeOrmEntityTables();
+        await app?.close();
+    });
+
+    describe('Cursor', () => {
+        it('should return 20 entities as default', async () => {
+            const { body: cursorBody } = await request(app.getHttpServer()).get(`/${PaginationType.CURSOR}`).expect(HttpStatus.OK);
+
+            expect(cursorBody.data).toHaveLength(defaultLimit);
+            expect(cursorBody.metadata).toEqual({
+                nextCursor: expect.any(String),
+                limit: defaultLimit,
+                total: totalCount,
+            });
+
+            const { body: searchBody } = await request(app.getHttpServer())
+                .post(`/${PaginationType.CURSOR}/search`)
+                .send()
+                .expect(HttpStatus.OK);
+            expect(searchBody.data).toHaveLength(defaultLimit);
+            expect(searchBody.metadata).toEqual({ limit: defaultLimit, total: totalCount, nextCursor: expect.any(String) });
+
+            const { body: searchNextBody } = await request(app.getHttpServer())
+                .post(`/${PaginationType.CURSOR}/search`)
+                .send({ nextCursor: searchBody.metadata.nextCursor, offset: defaultLimit })
+                .expect(HttpStatus.OK);
+            for (const entity of searchNextBody.data) {
+                expect(searchBody.data.some((data: { id: number }) => data.id === entity.id)).not.toBeTruthy();
+            }
+        });
+
+        it('should sort by pagination keys', async () => {
+            const { body: firstResponseBody } = await request(app.getHttpServer()).get(`/${PaginationType.CURSOR}`).expect(HttpStatus.OK);
+            expect(firstResponseBody.data).toHaveLength(defaultLimit);
+            for (const number of Array.from({ length: defaultLimit }, (_, index) => index)) {
+                expect(firstResponseBody.data[number].name).toEqual(`name-${(100 - number).toString().padStart(3, '0')}`);
+            }
+        });
+
+        it('should return next 20 entities after cursor', async () => {
+            const { body: firstResponseBody } = await request(app.getHttpServer()).get(`/${PaginationType.CURSOR}`).expect(HttpStatus.OK);
+
+            const { body: nextResponseBody } = await request(app.getHttpServer())
+                .get(`/${PaginationType.CURSOR}`)
+                .query({
+                    nextCursor: firstResponseBody.metadata.nextCursor,
+                })
+                .expect(HttpStatus.OK);
+
+            expect(firstResponseBody.metadata.nextCursor).not.toEqual(nextResponseBody.metadata.nextCursor);
+
+            expect(nextResponseBody.data).toHaveLength(defaultLimit);
+            expect(nextResponseBody.metadata).toEqual({
+                nextCursor: expect.any(String),
+                limit: defaultLimit,
+                total: totalCount,
+            });
+
+            for (const entity of nextResponseBody.data) {
+                expect(firstResponseBody.data.some((data: { id: number }) => data.id === entity.id)).not.toBeTruthy();
+            }
+
+            const lastOneOfFirstResponse = firstResponseBody.data.pop();
+            const firstOneOfNextResponse = nextResponseBody.data.shift();
+            expect(lastOneOfFirstResponse.id - 1).toEqual(firstOneOfNextResponse.id);
+            expect(lastOneOfFirstResponse.name).not.toEqual(firstOneOfNextResponse.name);
+        });
+    });
+
+    describe('Offset', () => {
+        it('should return 20 entities as default', async () => {
+            const { body } = await request(app.getHttpServer()).get(`/${PaginationType.OFFSET}`).expect(HttpStatus.OK);
+            expect(body.data).toHaveLength(defaultLimit);
+            expect(body.metadata).toEqual({ page: 1, pages: 5, total: totalCount, offset: defaultLimit, nextCursor: expect.any(String) });
+
+            const { body: searchBody } = await request(app.getHttpServer()).post(`/${PaginationType.OFFSET}/search`).expect(HttpStatus.OK);
+            expect(searchBody.data).toHaveLength(defaultLimit);
+            expect(searchBody.metadata).toEqual({
+                page: 1,
+                pages: 5,
+                total: totalCount,
+                offset: defaultLimit,
+                nextCursor: expect.any(String),
+            });
+
+            const { body: searchNextBody } = await request(app.getHttpServer())
+                .post(`/${PaginationType.OFFSET}/search`)
+                .send({ nextCursor: body.metadata.nextCursor, offset: defaultLimit })
+                .expect(HttpStatus.OK);
+            for (const entity of searchNextBody.data) {
+                expect(searchBody.data.some((data: { id: number }) => data.id === entity.id)).not.toBeTruthy();
+            }
+        });
+
+        it('should return next page from offset on readMany', async () => {
+            const { body: firstResponseBody } = await request(app.getHttpServer()).get(`/${PaginationType.OFFSET}`).expect(HttpStatus.OK);
+
+            const { body: nextResponseBody } = await request(app.getHttpServer())
+                .get(`/${PaginationType.OFFSET}`)
+                .query({
+                    nextCursor: firstResponseBody.metadata.nextCursor,
+                    offset: firstResponseBody.metadata.offset,
+                })
+                .expect(HttpStatus.OK);
+
+            expect(firstResponseBody.metadata).toEqual({
+                page: 1,
+                pages: 5,
+                total: totalCount,
+                offset: defaultLimit,
+                nextCursor: expect.any(String),
+            });
+
+            expect(nextResponseBody.metadata).toEqual({
+                page: 2,
+                pages: 5,
+                total: totalCount,
+                offset: defaultLimit * 2,
+                nextCursor: expect.any(String),
+            });
+        });
+
+        it('should return next page from offset on search', async () => {
+            const { body: firstResponseBody } = await request(app.getHttpServer())
+                .post(`/${PaginationType.OFFSET}/search`)
+                .expect(HttpStatus.OK);
+
+            const { body: nextResponseBody } = await request(app.getHttpServer())
+                .post(`/${PaginationType.OFFSET}/search`)
+                .send({
+                    nextCursor: firstResponseBody.metadata.nextCursor,
+                    offset: firstResponseBody.metadata.offset,
+                })
+                .expect(HttpStatus.OK);
+
+            expect(firstResponseBody.metadata).toEqual({
+                page: 1,
+                pages: 5,
+                total: totalCount,
+                offset: defaultLimit,
+                nextCursor: expect.any(String),
+            });
+
+            expect(nextResponseBody.metadata).toEqual({
+                page: 2,
+                pages: 5,
+                total: 100,
+                offset: defaultLimit * 2,
+                nextCursor: expect.any(String),
+            });
+        });
+    });
+});

--- a/spec/test.helper.ts
+++ b/spec/test.helper.ts
@@ -34,7 +34,9 @@ export class TestHelper {
                 return;
             }
             const entity = table.target as typeof BaseEntity;
-
+            if (!entity.query) {
+                return;
+            }
             await entity.query(`DROP TABLE ${table.name}`).catch((error) => {
                 if (failCount++ > 10) {
                     throw error;

--- a/src/lib/crud.route.factory.spec.ts
+++ b/src/lib/crud.route.factory.spec.ts
@@ -1,3 +1,4 @@
+import { UnprocessableEntityException } from '@nestjs/common';
 import { BaseEntity, Entity } from 'typeorm';
 
 import { CrudRouteFactory } from './crud.route.factory';
@@ -33,5 +34,27 @@ describe('CrudRouteFactory', () => {
                 },
             ).init(),
         ).toThrow(TypeError);
+    });
+
+    it('should be checked paginationKeys included in entity columns', () => {
+        expect(() =>
+            new CrudRouteFactory(
+                { prototype: {} },
+                {
+                    entity: TestEntity,
+                    routes: { search: { paginationKeys: ['wrong'] } },
+                },
+            ).init(),
+        ).toThrow(UnprocessableEntityException);
+
+        expect(() =>
+            new CrudRouteFactory(
+                { prototype: {} },
+                {
+                    entity: TestEntity,
+                    routes: { readMany: { paginationKeys: ['wrong'] } },
+                },
+            ).init(),
+        ).toThrow(UnprocessableEntityException);
     });
 });

--- a/src/lib/crud.route.factory.ts
+++ b/src/lib/crud.route.factory.ts
@@ -208,18 +208,24 @@ export class CrudRouteFactory {
             logger: this.crudLogger,
         };
 
-        let paginationType;
-        if (crudMethod === Method.READ_MANY || crudMethod === Method.SEARCH) {
-            paginationType = this.crudOptions.routes?.[crudMethod]?.paginationType ?? CRUD_POLICY[crudMethod].default.paginationType;
+        const needPagination = crudMethod === Method.READ_MANY || crudMethod === Method.SEARCH;
+        const paginationType = (() => {
+            if (!needPagination) {
+                return undefined;
+            }
+            const input = this.crudOptions.routes?.[crudMethod]?.paginationType ?? CRUD_POLICY[crudMethod].default.paginationType;
             const isPaginationType = (
                 <TEnum extends Record<string, unknown>>(enumType: TEnum) =>
                 (nextCursor: unknown): nextCursor is TEnum[keyof TEnum] =>
                     Object.values(enumType).includes(nextCursor as TEnum[keyof TEnum])
             )(PaginationType);
-            if (!isPaginationType(paginationType)) {
-                throw new TypeError(`invalid PaginationType ${paginationType}`);
+            if (!isPaginationType(input)) {
+                throw new TypeError(`invalid PaginationType ${input}`);
             }
+            return input;
+        })();
 
+        if (needPagination) {
             this.validatePaginationKeys(this.crudOptions.routes?.[crudMethod]?.paginationKeys);
         }
 

--- a/src/lib/interceptor/create-request.interceptor.spec.ts
+++ b/src/lib/interceptor/create-request.interceptor.spec.ts
@@ -28,7 +28,7 @@ describe('CreateRequestInterceptor', () => {
 
     it('should intercepts and validate body', async () => {
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        const Interceptor = CreateRequestInterceptor({ entity: BodyDto }, { relations: [], logger: new CrudLogger() });
+        const Interceptor = CreateRequestInterceptor({ entity: BodyDto }, { relations: [], logger: new CrudLogger(), primaryKeys: [] });
         const interceptor = new Interceptor() as InterceptorType;
         expect(await interceptor.validateBody({ col1: 1, col2: '2' })).toEqual({ col1: '1', col2: 2 });
         expect(await interceptor.validateBody({ col1: 1, col2: 2 })).toEqual({ col1: '1', col2: 2 });
@@ -40,7 +40,7 @@ describe('CreateRequestInterceptor', () => {
 
     it('should intercepts and validate body which is array', async () => {
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        const Interceptor = CreateRequestInterceptor({ entity: BodyDto }, { relations: [], logger: new CrudLogger() });
+        const Interceptor = CreateRequestInterceptor({ entity: BodyDto }, { relations: [], logger: new CrudLogger(), primaryKeys: [] });
         const interceptor = new Interceptor() as InterceptorType;
         expect(
             await interceptor.validateBody([

--- a/src/lib/interceptor/delete-request.interceptor.spec.ts
+++ b/src/lib/interceptor/delete-request.interceptor.spec.ts
@@ -13,7 +13,7 @@ describe('DeleteRequestInterceptor', () => {
             col1: string;
         }
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        const Interceptor = DeleteRequestInterceptor({ entity: BodyDto }, { relations: [], logger: new CrudLogger() });
+        const Interceptor = DeleteRequestInterceptor({ entity: BodyDto }, { relations: [], logger: new CrudLogger(), primaryKeys: [] });
         const interceptor = new Interceptor();
 
         const handler: CallHandler = {

--- a/src/lib/interceptor/read-many-request.interceptor.spec.ts
+++ b/src/lib/interceptor/read-many-request.interceptor.spec.ts
@@ -55,7 +55,7 @@ describe('ReadManyRequestInterceptor', () => {
             col3: number;
         }
 
-        const Interceptor = ReadManyRequestInterceptor({ entity: QueryDto }, { relations: [], logger: new CrudLogger() });
+        const Interceptor = ReadManyRequestInterceptor({ entity: QueryDto }, { relations: [], logger: new CrudLogger(), primaryKeys: [] });
         const interceptor = new Interceptor() as InterceptorType;
 
         expect(await interceptor.validateQuery(undefined as any)).toEqual({});
@@ -91,7 +91,10 @@ describe('ReadManyRequestInterceptor', () => {
         type InterceptorType = NestInterceptor<any, any> & {
             getRelations: (customReadManyRequestOptions: CustomReadManyRequestOptions) => string[];
         };
-        const Interceptor = ReadManyRequestInterceptor({ entity: {} as typeof BaseEntity }, { relations: [], logger: new CrudLogger() });
+        const Interceptor = ReadManyRequestInterceptor(
+            { entity: {} as typeof BaseEntity },
+            { relations: [], logger: new CrudLogger(), primaryKeys: [] },
+        );
         const interceptor = new Interceptor() as InterceptorType;
 
         expect(interceptor.getRelations({ relations: [] })).toEqual([]);
@@ -100,7 +103,7 @@ describe('ReadManyRequestInterceptor', () => {
 
         const InterceptorWithOptions = ReadManyRequestInterceptor(
             { entity: {} as typeof BaseEntity, routes: { readMany: { relations: ['option'] } } },
-            { relations: [], logger: new CrudLogger() },
+            { relations: [], logger: new CrudLogger(), primaryKeys: [] },
         );
         const interceptorWithOptions = new InterceptorWithOptions() as InterceptorType;
         expect(interceptorWithOptions.getRelations({ relations: [] })).toEqual([]);
@@ -109,7 +112,7 @@ describe('ReadManyRequestInterceptor', () => {
 
         const InterceptorWithFalseOptions = ReadManyRequestInterceptor(
             { entity: {} as typeof BaseEntity, routes: { readMany: { relations: false } } },
-            { relations: [], logger: new CrudLogger() },
+            { relations: [], logger: new CrudLogger(), primaryKeys: [] },
         );
         const interceptorWithFalseOptions = new InterceptorWithFalseOptions() as InterceptorType;
         expect(interceptorWithFalseOptions.getRelations({ relations: [] })).toEqual([]);

--- a/src/lib/interceptor/read-many-request.interceptor.ts
+++ b/src/lib/interceptor/read-many-request.interceptor.ts
@@ -43,9 +43,9 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
                 pagination.setWhere(PaginationHelper.serialize(query));
                 return query;
             })();
-
+            const paginationKeys = readManyOptions?.paginationKeys ?? factoryOption.primaryKeys?.map(({ name }) => name) ?? [];
             const crudReadManyRequest: CrudReadManyRequest<typeof crudOptions.entity> = new CrudReadManyRequest<typeof crudOptions.entity>()
-                .setPrimaryKey(factoryOption.primaryKeys ?? [])
+                .setPaginationKeys(paginationKeys)
                 .setExcludeColumn(readManyOptions.exclude)
                 .setPagination(pagination)
                 .setWithDeleted(

--- a/src/lib/interceptor/read-many-request.interceptor.ts
+++ b/src/lib/interceptor/read-many-request.interceptor.ts
@@ -43,7 +43,7 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
                 pagination.setWhere(PaginationHelper.serialize(query));
                 return query;
             })();
-            const paginationKeys = readManyOptions.paginationKeys ?? factoryOption.primaryKeys?.map(({ name }) => name) ?? [];
+            const paginationKeys = readManyOptions.paginationKeys ?? factoryOption.primaryKeys.map(({ name }) => name);
             const crudReadManyRequest: CrudReadManyRequest<typeof crudOptions.entity> = new CrudReadManyRequest<typeof crudOptions.entity>()
                 .setPaginationKeys(paginationKeys)
                 .setExcludeColumn(readManyOptions.exclude)

--- a/src/lib/interceptor/read-many-request.interceptor.ts
+++ b/src/lib/interceptor/read-many-request.interceptor.ts
@@ -43,7 +43,7 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
                 pagination.setWhere(PaginationHelper.serialize(query));
                 return query;
             })();
-            const paginationKeys = readManyOptions?.paginationKeys ?? factoryOption.primaryKeys?.map(({ name }) => name) ?? [];
+            const paginationKeys = readManyOptions.paginationKeys ?? factoryOption.primaryKeys?.map(({ name }) => name) ?? [];
             const crudReadManyRequest: CrudReadManyRequest<typeof crudOptions.entity> = new CrudReadManyRequest<typeof crudOptions.entity>()
                 .setPaginationKeys(paginationKeys)
                 .setExcludeColumn(readManyOptions.exclude)

--- a/src/lib/interceptor/read-one-request.interceptor.spec.ts
+++ b/src/lib/interceptor/read-one-request.interceptor.spec.ts
@@ -17,7 +17,7 @@ describe('ReadOneRequestInterceptor', () => {
     it('should intercept and pass CrudReadOneRequest', async () => {
         const Interceptor = ReadOneRequestInterceptor(
             { entity: {} as typeof BaseEntity },
-            { columns: [{ name: 'col1', type: 'string', isPrimary: false }], relations: [], logger: new CrudLogger() },
+            { columns: [{ name: 'col1', type: 'string', isPrimary: false }], relations: [], logger: new CrudLogger(), primaryKeys: [] },
         );
         const interceptor = new Interceptor();
 
@@ -28,7 +28,10 @@ describe('ReadOneRequestInterceptor', () => {
     });
 
     it('should get fields from interceptor fields and request fields', () => {
-        const Interceptor = ReadOneRequestInterceptor({ entity: {} as typeof BaseEntity }, { relations: [], logger: new CrudLogger() });
+        const Interceptor = ReadOneRequestInterceptor(
+            { entity: {} as typeof BaseEntity },
+            { relations: [], logger: new CrudLogger(), primaryKeys: [] },
+        );
         const interceptor = new Interceptor() as NestInterceptor<any, any> & {
             getFields: (interceptorFields?: string[], requestFields?: string[]) => string | undefined;
         };
@@ -52,6 +55,7 @@ describe('ReadOneRequestInterceptor', () => {
                 ],
                 relations: [],
                 logger: new CrudLogger(),
+                primaryKeys: [],
             },
         );
         const interceptor = new Interceptor() as NestInterceptor<any, any> & {
@@ -77,7 +81,7 @@ describe('ReadOneRequestInterceptor', () => {
     it('should throw when fields are invalid', () => {
         const Interceptor = ReadOneRequestInterceptor(
             { entity: {} as typeof BaseEntity },
-            { columns: [], relations: [], logger: new CrudLogger() },
+            { columns: [], relations: [], logger: new CrudLogger(), primaryKeys: [] },
         );
         const interceptor = new Interceptor() as NestInterceptor<any, any> & {
             checkFields: (fields?: unknown) => string | undefined;
@@ -92,7 +96,10 @@ describe('ReadOneRequestInterceptor', () => {
     });
 
     it('should get relations from custom request options and crudOption', async () => {
-        const Interceptor = ReadOneRequestInterceptor({ entity: {} as typeof BaseEntity }, { relations: [], logger: new CrudLogger() });
+        const Interceptor = ReadOneRequestInterceptor(
+            { entity: {} as typeof BaseEntity },
+            { relations: [], logger: new CrudLogger(), primaryKeys: [] },
+        );
         const interceptor = new Interceptor();
 
         const mockRequest: any = jest.fn();
@@ -103,7 +110,7 @@ describe('ReadOneRequestInterceptor', () => {
 
         const InterceptorNoRelations = ReadOneRequestInterceptor(
             { entity: {} as typeof BaseEntity, routes: { [Method.READ_ONE]: { relations: false } } },
-            { relations: [], logger: new CrudLogger() },
+            { relations: [], logger: new CrudLogger(), primaryKeys: [] },
         );
         const interceptorNoRelations = new InterceptorNoRelations();
 
@@ -115,7 +122,7 @@ describe('ReadOneRequestInterceptor', () => {
 
         const InterceptorWithRelations = ReadOneRequestInterceptor(
             { entity: {} as typeof BaseEntity, routes: { [Method.READ_ONE]: { relations: ['bar'] } } },
-            { relations: [], logger: new CrudLogger() },
+            { relations: [], logger: new CrudLogger(), primaryKeys: [] },
         );
         const interceptorWithRelations = new InterceptorWithRelations();
 

--- a/src/lib/interceptor/recover-request.interceptor.spec.ts
+++ b/src/lib/interceptor/recover-request.interceptor.spec.ts
@@ -13,7 +13,7 @@ describe('RecoverRequestInterceptor', () => {
             col1: string;
         }
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        const Interceptor = RecoverRequestInterceptor({ entity: BodyDto }, { relations: [], logger: new CrudLogger() });
+        const Interceptor = RecoverRequestInterceptor({ entity: BodyDto }, { relations: [], logger: new CrudLogger(), primaryKeys: [] });
         const interceptor = new Interceptor();
         const handler: CallHandler = {
             handle: () => of('test'),

--- a/src/lib/interceptor/search-request.interceptor.spec.ts
+++ b/src/lib/interceptor/search-request.interceptor.spec.ts
@@ -35,6 +35,7 @@ describe('SearchRequestInterceptor', () => {
                 ],
                 relations: [],
                 logger: new CrudLogger(),
+                primaryKeys: [],
             },
         );
         interceptor = new Interceptor();
@@ -267,7 +268,10 @@ describe('SearchRequestInterceptor', () => {
         type InterceptorType = NestInterceptor<any, any> & {
             getRelations: (customSearchRequestOptions: CustomSearchRequestOptions) => string[];
         };
-        const Interceptor = SearchRequestInterceptor({ entity: {} as typeof BaseEntity }, { relations: [], logger: new CrudLogger() });
+        const Interceptor = SearchRequestInterceptor(
+            { entity: {} as typeof BaseEntity },
+            { relations: [], logger: new CrudLogger(), primaryKeys: [] },
+        );
         const interceptor = new Interceptor() as InterceptorType;
         expect(interceptor.getRelations({ relations: [] })).toEqual([]);
         expect(interceptor.getRelations({ relations: ['table'] })).toEqual(['table']);
@@ -275,7 +279,7 @@ describe('SearchRequestInterceptor', () => {
 
         const InterceptorWithoutSearchRoute = SearchRequestInterceptor(
             { entity: {} as typeof BaseEntity, routes: { readOne: { relations: false } } },
-            { relations: [], logger: new CrudLogger() },
+            { relations: [], logger: new CrudLogger(), primaryKeys: [] },
         );
         const interceptorWithoutSearchRoute = new InterceptorWithoutSearchRoute() as InterceptorType;
         expect(interceptorWithoutSearchRoute.getRelations({ relations: [] })).toEqual([]);
@@ -284,7 +288,7 @@ describe('SearchRequestInterceptor', () => {
 
         const InterceptorWithoutRelations = SearchRequestInterceptor(
             { entity: {} as typeof BaseEntity, routes: { search: {} } },
-            { relations: [], logger: new CrudLogger() },
+            { relations: [], logger: new CrudLogger(), primaryKeys: [] },
         );
         const interceptorWithoutRelations = new InterceptorWithoutRelations() as InterceptorType;
         expect(interceptorWithoutRelations.getRelations({ relations: [] })).toEqual([]);
@@ -293,7 +297,7 @@ describe('SearchRequestInterceptor', () => {
 
         const InterceptorWithOptions = SearchRequestInterceptor(
             { entity: {} as typeof BaseEntity, routes: { search: { relations: ['option'] } } },
-            { relations: [], logger: new CrudLogger() },
+            { relations: [], logger: new CrudLogger(), primaryKeys: [] },
         );
         const interceptorWithOptions = new InterceptorWithOptions() as InterceptorType;
         expect(interceptorWithOptions.getRelations({ relations: [] })).toEqual([]);
@@ -302,7 +306,7 @@ describe('SearchRequestInterceptor', () => {
 
         const InterceptorWithFalseOptions = SearchRequestInterceptor(
             { entity: {} as typeof BaseEntity, routes: { search: { relations: false } } },
-            { relations: [], logger: new CrudLogger() },
+            { relations: [], logger: new CrudLogger(), primaryKeys: [] },
         );
         const interceptorWithFalseOptions = new InterceptorWithFalseOptions() as InterceptorType;
         expect(interceptorWithFalseOptions.getRelations({ relations: [] })).toEqual([]);

--- a/src/lib/interceptor/search-request.interceptor.ts
+++ b/src/lib/interceptor/search-request.interceptor.ts
@@ -64,11 +64,11 @@ export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption
                       )
                     : [];
 
-            const primaryKeys = factoryOption.primaryKeys ?? [];
-            requestSearchDto.order ??= primaryKeys.reduce((acc, { name }) => ({ ...acc, [name]: CRUD_POLICY[method].default.sort }), {});
+            const paginationKeys = searchOptions.paginationKeys ?? factoryOption.primaryKeys?.map(({ name }) => name) ?? [];
+            requestSearchDto.order ??= paginationKeys.reduce((acc, key) => ({ ...acc, [key]: CRUD_POLICY[method].default.sort }), {});
 
             const crudReadManyRequest: CrudReadManyRequest<typeof crudOptions.entity> = new CrudReadManyRequest<typeof crudOptions.entity>()
-                .setPrimaryKey(primaryKeys)
+                .setPaginationKeys(paginationKeys)
                 .setPagination(pagination)
                 .setSelectColumn(requestSearchDto.select)
                 .setExcludeColumn(searchOptions.exclude)

--- a/src/lib/interceptor/search-request.interceptor.ts
+++ b/src/lib/interceptor/search-request.interceptor.ts
@@ -64,7 +64,7 @@ export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption
                       )
                     : [];
 
-            const paginationKeys = searchOptions.paginationKeys ?? factoryOption.primaryKeys?.map(({ name }) => name) ?? [];
+            const paginationKeys = searchOptions.paginationKeys ?? factoryOption.primaryKeys.map(({ name }) => name);
             requestSearchDto.order ??= paginationKeys.reduce((acc, key) => ({ ...acc, [key]: CRUD_POLICY[method].default.sort }), {});
 
             const crudReadManyRequest: CrudReadManyRequest<typeof crudOptions.entity> = new CrudReadManyRequest<typeof crudOptions.entity>()

--- a/src/lib/interface/decorator-option.interface.ts
+++ b/src/lib/interface/decorator-option.interface.ts
@@ -116,6 +116,11 @@ export interface CrudOptions {
              * @default true
              */
             softDelete?: boolean;
+            /**
+             * Keys to use for pagination.
+             * If not set, the keys will be taken from the entity's primary keys.
+             */
+            paginationKeys?: string[];
         } & Omit<RouteBaseOption, 'response'>;
         [Method.SEARCH]?: {
             /**
@@ -143,6 +148,11 @@ export interface CrudOptions {
              * @default true
              */
             softDelete?: boolean;
+            /**
+             * Keys to use for pagination.
+             * If not set, the keys will be taken from the entity's primary keys.
+             */
+            paginationKeys?: string[];
         } & RouteBaseOption;
         [Method.CREATE]?: {
             swagger?: {

--- a/src/lib/interface/factory-option.interface.ts
+++ b/src/lib/interface/factory-option.interface.ts
@@ -12,5 +12,5 @@ export interface FactoryOption {
     logger: CrudLogger;
     columns?: Column[];
     relations: string[];
-    primaryKeys?: Array<Omit<Column, 'isPrimary'>>;
+    primaryKeys: Array<Omit<Column, 'isPrimary'>>;
 }

--- a/src/lib/request/read-many.request.ts
+++ b/src/lib/request/read-many.request.ts
@@ -2,12 +2,12 @@ import _ from 'lodash';
 import { FindManyOptions, FindOptionsOrder, FindOptionsSelect, FindOptionsWhere } from 'typeorm';
 
 import { CRUD_POLICY } from '../crud.policy';
-import { Method, PaginationRequest, PaginationResponse, PaginationType, PrimaryKey, Sort } from '../interface';
+import { Method, PaginationRequest, PaginationResponse, PaginationType, Sort } from '../interface';
 import { PaginationHelper } from '../provider';
 
 type Where<T> = FindOptionsWhere<T> | Array<FindOptionsWhere<T>>;
 export class CrudReadManyRequest<T> {
-    private _primaryKeys: PrimaryKey[] = [];
+    private _paginationKeys: string[] = [];
     private _findOptions: FindManyOptions<T> & {
         where: Where<T>;
         take: number;
@@ -23,8 +23,8 @@ export class CrudReadManyRequest<T> {
     private _selectColumnSet: Set<string | number> = new Set();
     private _excludeColumnSet: Set<string> = new Set();
 
-    get primaryKeys() {
-        return this._primaryKeys;
+    get paginationKeys() {
+        return this._paginationKeys;
     }
 
     get findOptions() {
@@ -57,8 +57,8 @@ export class CrudReadManyRequest<T> {
         return this;
     }
 
-    setPrimaryKey(primaryKeys: PrimaryKey[]): this {
-        this._primaryKeys = primaryKeys;
+    setPaginationKeys(paginationKeys: string[]): this {
+        this._paginationKeys = paginationKeys;
         return this;
     }
 
@@ -99,7 +99,7 @@ export class CrudReadManyRequest<T> {
 
     setSort(sort: Sort): this {
         this._sort = sort;
-        this._findOptions.order = this._primaryKeys.reduce((order, primaryKey) => ({ ...order, [primaryKey.name]: sort }), {});
+        this._findOptions.order = this._paginationKeys.reduce((order, paginationKey) => ({ ...order, [paginationKey]: sort }), {});
         return this;
     }
 
@@ -144,12 +144,7 @@ export class CrudReadManyRequest<T> {
     toResponse(data: T[], total: number): PaginationResponse<T> {
         const take = this.findOptions.take;
         const dataLength = data.length;
-        const nextCursor = PaginationHelper.serialize(
-            _.pick(
-                data.at(-1),
-                this.primaryKeys.map(({ name }) => name),
-            ) as FindOptionsWhere<T>,
-        );
+        const nextCursor = PaginationHelper.serialize(_.pick(data.at(-1), this.paginationKeys) as FindOptionsWhere<T>);
 
         if (this.pagination.type === PaginationType.OFFSET) {
             return {

--- a/src/lib/request/read-many.request.ts
+++ b/src/lib/request/read-many.request.ts
@@ -144,7 +144,8 @@ export class CrudReadManyRequest<T> {
     toResponse(data: T[], total: number): PaginationResponse<T> {
         const take = this.findOptions.take;
         const dataLength = data.length;
-        const nextCursor = PaginationHelper.serialize(_.pick(data.at(-1), this.paginationKeys) as FindOptionsWhere<T>);
+        const orderKeys = Object.keys(this._findOptions.order);
+        const nextCursor = PaginationHelper.serialize(_.pick(data.at(-1), orderKeys) as FindOptionsWhere<T>);
 
         if (this.pagination.type === PaginationType.OFFSET) {
             return {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #456

## What is the new behavior?

- provide paginationKeys as options for readMany and search route.
- if paginationKeys are not explicitly set, primary keys are set as default.
- cursor for pagination operates based on the pagination keys.
- returned items are sorted by pagination keys.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
