### PR TITLE
feat: add validation to check if CrudService is included as member of controller

### DIFF
--- a/spec/base/base.controller.spec.ts
+++ b/spec/base/base.controller.spec.ts
@@ -31,7 +31,7 @@ describe('BaseController', () => {
     });
 
     it('dynamic method on controller', async () => {
-        const controllerPrototype = Object.getPrototypeOf(controller);
+        const controllerPrototype = Object.getPrototypeOf(Object.getPrototypeOf(controller));
         const propertyNames = Object.getOwnPropertyNames(controllerPrototype).filter((name) => name !== 'constructor');
 
         const expectedMethods = [

--- a/spec/exclude-swagger/exclude-swagger.spec.ts
+++ b/spec/exclude-swagger/exclude-swagger.spec.ts
@@ -91,7 +91,7 @@ describe('exclude swagger by route', () => {
         expect(routeSet[create].root).toEqual({
             method: 'post',
             path: '/exclude-swagger',
-            operationId: 'ExcludeSwaggerController_reservedCreate',
+            operationId: 'reservedCreate',
             summary: "create one to 'Base' Table",
             description: "Create an entity in 'Base' Table",
             parameters: [],

--- a/src/lib/crud.decorator.spec.ts
+++ b/src/lib/crud.decorator.spec.ts
@@ -1,0 +1,36 @@
+/* eslint-disable max-classes-per-file */
+import { BaseEntity, Entity, Repository } from 'typeorm';
+
+import { Crud } from './crud.decorator';
+import { CrudService } from './crud.service';
+
+describe('Crud.Decorator', () => {
+    @Entity('test')
+    class TestEntity extends BaseEntity {}
+
+    @Crud({
+        entity: TestEntity,
+    })
+    class TestController {
+        constructor(public readonly crudService: any) {}
+    }
+
+    describe('should check crudService is included as a member of target, and is instance of CrudService', () => {
+        it('crudService(instance of CrudService) not throw error', () => {
+            const mockRepository = {
+                metadata: {
+                    primaryColumns: [],
+                    columns: [],
+                },
+            };
+            const crudService = new CrudService(mockRepository as unknown as Repository<TestEntity>);
+            expect(() => new TestController(crudService)).not.toThrow();
+        });
+
+        test.each([undefined, null, 'wrong', {}, []])('crudService(%p) throw error', (crudService: any) => {
+            expect(() => new TestController(crudService)).toThrow(
+                new TypeError('controller should include member crudService, which is instance of CrudService'),
+            );
+        });
+    });
+});

--- a/src/lib/crud.decorator.ts
+++ b/src/lib/crud.decorator.ts
@@ -1,10 +1,20 @@
 import { CrudRouteFactory } from './crud.route.factory';
+import { CrudService } from './crud.service';
 import { CrudOptions } from './interface';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const Crud =
     (options: CrudOptions) =>
-    (target: unknown): void => {
+    <T extends { new (...args: any[]): any }>(target: T) => {
         const crudRouteFactory = new CrudRouteFactory(target, options);
         crudRouteFactory.init();
+
+        return class extends target {
+            constructor(...args: any[]) {
+                super(...args);
+                if (!(this.crudService instanceof CrudService)) {
+                    throw new TypeError('controller should include member crudService, which is instance of CrudService');
+                }
+            }
+        };
     };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

It does not validate whether CrudService has been properly inserted as a member in the controller. 
This leads to undefined reference errors when the API is called later.

Issue Number: N/A

## What is the new behavior?

It validates at the time of the instantiation of controller to check if CrudService is included as a member. 
If not properly included, throw error.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
