### PR TITLE
feat: changed request body schema name when using omitted/picked type

### DIFF
--- a/spec/exclude-swagger/exclude-swagger.spec.ts
+++ b/spec/exclude-swagger/exclude-swagger.spec.ts
@@ -101,14 +101,14 @@ describe('exclude swagger by route', () => {
                 content: {
                     'application/json': {
                         schema: {
-                            $ref: '#/components/schemas/PickTypeClass',
+                            $ref: '#/components/schemas/CreateBaseBodyDto',
                             anyOf: [
                                 {
-                                    $ref: '#/components/schemas/PickTypeClass',
+                                    $ref: '#/components/schemas/CreateBaseBodyDto',
                                 },
                                 {
                                     items: {
-                                        $ref: '#/components/schemas/PickTypeClass',
+                                        $ref: '#/components/schemas/CreateBaseBodyDto',
                                     },
                                     type: 'array',
                                 },

--- a/src/lib/crud.route.factory.spec.ts
+++ b/src/lib/crud.route.factory.spec.ts
@@ -9,52 +9,36 @@ describe('CrudRouteFactory', () => {
     class TestEntity extends BaseEntity {}
 
     it('should check tableName in TypeORM', () => {
-        expect(() => new CrudRouteFactory({ prototype: {} }, { entity: {} as typeof BaseEntity })).toThrow(Error);
+        expect(() => new CrudRouteFactory({ prototype: {} }, { entity: {} as typeof BaseEntity })).toThrow(
+            new Error('Cannot find Table from TypeORM'),
+        );
     });
 
-    it('should be checked paginationType of readMany route', () => {
-        expect(() =>
-            new CrudRouteFactory(
-                { prototype: {} },
-                {
-                    entity: TestEntity,
-                    routes: { readMany: { paginationType: 'wrong' as unknown as PaginationType } },
-                },
-            ).init(),
-        ).toThrow(TypeError);
+    describe('should be checked paginationType', () => {
+        test.each(['readMany', 'search'])('route(%s)', (route) => {
+            expect(() =>
+                new CrudRouteFactory(
+                    { prototype: {} },
+                    {
+                        entity: TestEntity,
+                        routes: { [route]: { paginationType: 'wrong' as unknown as PaginationType } },
+                    },
+                ).init(),
+            ).toThrow(new TypeError('invalid PaginationType wrong'));
+        });
     });
 
-    it('should be checked paginationType of search route', () => {
-        expect(() =>
-            new CrudRouteFactory(
-                { prototype: {} },
-                {
-                    entity: TestEntity,
-                    routes: { search: { paginationType: 'wrong' as unknown as PaginationType } },
-                },
-            ).init(),
-        ).toThrow(TypeError);
-    });
-
-    it('should be checked paginationKeys included in entity columns', () => {
-        expect(() =>
-            new CrudRouteFactory(
-                { prototype: {} },
-                {
-                    entity: TestEntity,
-                    routes: { search: { paginationKeys: ['wrong'] } },
-                },
-            ).init(),
-        ).toThrow(UnprocessableEntityException);
-
-        expect(() =>
-            new CrudRouteFactory(
-                { prototype: {} },
-                {
-                    entity: TestEntity,
-                    routes: { readMany: { paginationKeys: ['wrong'] } },
-                },
-            ).init(),
-        ).toThrow(UnprocessableEntityException);
+    describe('should be checked paginationKeys included in entity columns', () => {
+        test.each(['readMany', 'search'])('route(%s)', (route) => {
+            expect(() =>
+                new CrudRouteFactory(
+                    { prototype: {} },
+                    {
+                        entity: TestEntity,
+                        routes: { [route]: { paginationKeys: ['wrong'] } },
+                    },
+                ).init(),
+            ).toThrow(new UnprocessableEntityException('pagination key wrong is unknown'));
+        });
     });
 });

--- a/src/lib/crud.route.factory.ts
+++ b/src/lib/crud.route.factory.ts
@@ -101,11 +101,8 @@ export class CrudRouteFactory {
                 return namingStrategy(typeof discriminatorValue === 'string' ? discriminatorValue : discriminatorValue?.name);
             }
 
-            return namingStrategy(table?.name);
+            return namingStrategy(table.name);
         })();
-        if (!tableName) {
-            throw new Error('Cannot find Entity name from TypeORM');
-        }
         this.entity.tableName = tableName;
 
         const inheritanceTree = MetadataUtils.getInheritanceTree(entity as Function);
@@ -194,9 +191,6 @@ export class CrudRouteFactory {
         }
 
         const methodName = this.writeMethodOnController(crudMethod);
-        if (!methodName) {
-            throw new Error(`Required Method Name of ${crudMethod}`);
-        }
 
         const targetMethod = this.targetPrototype[methodName];
         const { path, params } = CRUD_POLICY[crudMethod].uriParameter(this.crudOptions, this.entity.primaryKeys);

--- a/src/lib/crud.route.factory.ts
+++ b/src/lib/crud.route.factory.ts
@@ -280,8 +280,9 @@ export class CrudRouteFactory {
         Reflect.defineMetadata(DECORATORS.API_OPERATION, CRUD_POLICY[method].swagger.operationMetadata(this.tableName), target);
         this.defineParameterSwagger(method, params, target, paginationType);
 
-        if (this.crudOptions.routes?.[method]?.swagger?.response) {
-            const responseDto = this.generalTypeGuard(this.crudOptions.routes?.[method]?.swagger?.response!, method, 'response');
+        const routeConfig = this.crudOptions.routes?.[method];
+        if (routeConfig?.swagger?.response) {
+            const responseDto = this.generalTypeGuard(routeConfig.swagger.response, method, 'response');
             const extraModels: Array<{ name: string }> = Reflect.getMetadata(DECORATORS.API_EXTRA_MODELS, target) ?? [];
             if (!extraModels.some((model) => model.name === responseDto.name)) {
                 Reflect.defineMetadata(DECORATORS.API_EXTRA_MODELS, [...extraModels, responseDto], target);
@@ -351,18 +352,13 @@ export class CrudRouteFactory {
         }
         if (CRUD_POLICY[method].useBody) {
             const bodyType = (() => {
-                const customBody = this.crudOptions.routes?.[method]?.swagger?.body;
-                if (customBody != null) {
-                    return customBody;
+                const routeConfig = this.crudOptions.routes?.[method];
+                if (routeConfig?.swagger?.body) {
+                    return this.generalTypeGuard(routeConfig.swagger.body, method, 'body');
                 }
                 if (method === Method.SEARCH) {
                     return RequestSearchDto;
                 }
-                const routeConfig = this.crudOptions.routes?.[method];
-                if (routeConfig?.swagger && 'body' in routeConfig.swagger) {
-                    return this.generalTypeGuard(routeConfig.swagger['body']!, method, 'body');
-                }
-
                 return CreateRequestDto(this.crudOptions.entity, method);
             })();
 

--- a/src/lib/request/read-many.request.ts
+++ b/src/lib/request/read-many.request.ts
@@ -99,7 +99,7 @@ export class CrudReadManyRequest<T> {
 
     setSort(sort: Sort): this {
         this._sort = sort;
-        this._findOptions.order = this._paginationKeys.reduce((order, paginationKey) => ({ ...order, [paginationKey]: sort }), {});
+        this._findOptions.order = this.paginationKeys.reduce((order, paginationKey) => ({ ...order, [paginationKey]: sort }), {});
         return this;
     }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When using OmitType or PickType in the swagger.body configuration, the schema name become PickTypeClass or OmitTypeClass.

Issue Number: N/A

## What is the new behavior?

It uses schema name which reflect crud method, table name, and source.
ex) 'create' route, 'base' table, request body -> CreateBaseBodyDto

Additionally, improved test code to validate exception message, and remove unnecessary null checks and optional chaining

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
