### PR TITLE
feat: modified to filter items based on options in request when nextCursor is invalid

### DIFF
--- a/spec/pagination/pagination.spec.ts
+++ b/spec/pagination/pagination.spec.ts
@@ -536,5 +536,37 @@ describe('Pagination', () => {
             expect(lastOneOfFirstResponse.type).toEqual(0);
             expect(firstOneOfNextResponse.type).toEqual(1);
         });
+
+        it('should return items queried based on request when nextCursor is invalid', async () => {
+            // readMany
+            const { body: readManyResponseBody } = await request(app.getHttpServer())
+                .get(`/${PaginationType.OFFSET}`)
+                .query({
+                    nextCursor: 'invalid',
+                    type: 1,
+                })
+                .expect(HttpStatus.OK);
+
+            expect(readManyResponseBody.metadata).toEqual({
+                page: 1,
+                pages: 3,
+                total: 50,
+                offset: 20,
+                nextCursor: expect.any(String),
+            });
+
+            // search
+            const { body: searchResponseBody } = await request(app.getHttpServer())
+                .post(`/${PaginationType.OFFSET}/search`)
+                .send({ where: [{ type: { operator: '=', operand: 1 } }], nextCursor: 'invalid' })
+                .expect(HttpStatus.OK);
+            expect(searchResponseBody.metadata).toEqual({
+                page: 1,
+                pages: 3,
+                total: 50,
+                offset: 20,
+                nextCursor: expect.any(String),
+            });
+        });
     });
 });

--- a/spec/pagination/pagination.spec.ts
+++ b/spec/pagination/pagination.spec.ts
@@ -246,6 +246,37 @@ describe('Pagination', () => {
             expect(lastOneOfFirstResponse.type).toEqual(0);
             expect(firstOneOfNextResponse.type).toEqual(1);
         });
+
+        it('should return items queried based on request when nextCursor is invalid', async () => {
+            // readMany
+            const { body: responseBody } = await request(app.getHttpServer())
+                .get(`/${PaginationType.CURSOR}`)
+                .query({
+                    type: 1,
+                    nextCursor: 'invalid',
+                })
+                .expect(HttpStatus.OK);
+
+            expect(responseBody.data).toHaveLength(20);
+            expect(responseBody.metadata).toEqual({
+                nextCursor: expect.any(String),
+                limit: 20,
+                total: 50,
+            });
+
+            // search
+            const { body: searchResponseBody } = await request(app.getHttpServer())
+                .post(`/${PaginationType.CURSOR}/search`)
+                .send({ where: [{ type: { operator: '=', operand: 1 } }], nextCursor: 'invalid' })
+                .expect(HttpStatus.OK);
+
+            expect(searchResponseBody.data).toHaveLength(20);
+            expect(searchResponseBody.metadata).toEqual({
+                nextCursor: expect.any(String),
+                limit: 20,
+                total: 50,
+            });
+        });
     });
 
     describe('Offset', () => {

--- a/src/lib/abstract/abstract.pagination.spec.ts
+++ b/src/lib/abstract/abstract.pagination.spec.ts
@@ -25,7 +25,8 @@ describe('AbstractPaginationRequest', () => {
 
     it('should do nothing when query is invalid', () => {
         const paginationRequest = new PaginationRequest();
-        paginationRequest.setQuery('invalid');
+        const isQueryValid = paginationRequest.setQuery('invalid');
+        expect(isQueryValid).toEqual(false);
         expect(paginationRequest.isNext).toBeFalsy();
     });
 });

--- a/src/lib/abstract/abstract.pagination.ts
+++ b/src/lib/abstract/abstract.pagination.ts
@@ -44,17 +44,25 @@ export abstract class AbstractPaginationRequest {
         ).toString(encoding);
     }
 
-    setQuery(query: string): void {
-        try {
-            const paginationType: PaginationQuery = JSON.parse(Buffer.from(query, encoding).toString());
-            this._where = paginationType.where;
-            this._total = paginationType.total;
-            this._nextCursor = paginationType.nextCursor;
-
-            this._isNext = true;
-        } catch {
-            //
+    setQuery(query: string): boolean {
+        const paginationQuery: PaginationQuery | null = (() => {
+            try {
+                return JSON.parse(Buffer.from(query, encoding).toString());
+            } catch {
+                return null;
+            }
+        })();
+        if (paginationQuery == null) {
+            return false;
         }
+
+        this._where = paginationQuery.where;
+        this._total = paginationQuery.total;
+        this._nextCursor = paginationQuery.nextCursor;
+
+        this._isNext = true;
+
+        return true;
     }
 
     protected get total(): number {

--- a/src/lib/abstract/abstract.request.interceptor.ts
+++ b/src/lib/abstract/abstract.request.interceptor.ts
@@ -43,7 +43,7 @@ export abstract class RequestAbstractInterceptor {
         crudOptions: CrudOptions,
         method: Exclude<Method, Method.READ_MANY | Method.READ_ONE | Method.SEARCH>,
     ): Author | undefined {
-        const author = crudOptions?.routes?.[method]?.author;
+        const author = crudOptions.routes?.[method]?.author;
 
         if (!author) {
             return;

--- a/src/lib/dto/request-search.dto.ts
+++ b/src/lib/dto/request-search.dto.ts
@@ -44,7 +44,4 @@ export class RequestSearchDto<T> {
 
     @ApiPropertyOptional({ description: 'Use to search the next page', type: String })
     nextCursor?: string;
-
-    @ApiPropertyOptional({ description: 'Use to search the next page under the same conditions', type: String })
-    query?: string;
 }

--- a/src/lib/dto/request-search.dto.ts
+++ b/src/lib/dto/request-search.dto.ts
@@ -4,7 +4,7 @@ import { Sort } from '../interface';
 import { QueryFilter, operators } from '../interface/query-operation.interface';
 
 export class RequestSearchDto<T> {
-    @ApiPropertyOptional({ description: 'select fields', isArray: true, type: [String] })
+    @ApiPropertyOptional({ description: 'select fields', isArray: true, type: String })
     select?: Array<keyof Partial<T>>;
 
     @ApiPropertyOptional({
@@ -39,7 +39,7 @@ export class RequestSearchDto<T> {
     @ApiPropertyOptional({ description: 'withDeleted', type: Boolean })
     withDeleted?: boolean;
 
-    @ApiPropertyOptional({ description: 'take', type: Number })
+    @ApiPropertyOptional({ description: 'take', type: Number, example: 20 })
     take?: number;
 
     @ApiPropertyOptional({ description: 'Use to search the next page', type: String })

--- a/src/lib/interceptor/read-many-request.interceptor.ts
+++ b/src/lib/interceptor/read-many-request.interceptor.ts
@@ -42,8 +42,10 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
 
             const query = await (async () => {
                 if (PaginationHelper.isNextPage(pagination)) {
-                    pagination.setQuery(pagination.query ?? btoa('{}'));
-                    return {};
+                    const isQueryValid = pagination.setQuery(pagination.query);
+                    if (isQueryValid) {
+                        return {};
+                    }
                 }
                 const query = await this.validateQuery(req.query);
                 pagination.setWhere(PaginationHelper.serialize(query));
@@ -82,6 +84,9 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
             }
             if ('offset' in query) {
                 delete query.offset;
+            }
+            if ('nextCursor' in query) {
+                delete query.nextCursor;
             }
 
             const transformed = plainToInstance(crudOptions.entity as ClassConstructor<EntityType>, query, {

--- a/src/lib/interceptor/search-request.interceptor.ts
+++ b/src/lib/interceptor/search-request.interceptor.ts
@@ -51,8 +51,10 @@ export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption
 
             const requestSearchDto = await (async () => {
                 if (isNextPage) {
-                    pagination.setQuery(pagination.query ?? btoa('{}'));
-                    return PaginationHelper.deserialize<RequestSearchDto<EntityType>>(pagination.where);
+                    const isQueryValid = pagination.setQuery(pagination.query);
+                    if (isQueryValid) {
+                        return PaginationHelper.deserialize<RequestSearchDto<EntityType>>(pagination.where);
+                    }
                 }
                 const searchBody = await this.validateBody(req.body);
                 pagination.setWhere(PaginationHelper.serialize((searchBody ?? {}) as FindOptionsWhere<typeof crudOptions.entity>));


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When invalid value is passed to nextCursor in a search or readMany request, any specified where condition in the request is ignored, and no filtering is applied.

Issue Number: N/A

## What is the new behavior?

When nextCursor is invalid, items are filtered based on specified where condition (search - request.body.where, readMany - request.query).

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Additionally, I corrected some mismatched type and removed unnecessary field(query) in swagger docs.