### PR TITLE
fix: fixed so that name of extended controller follow original name

### DIFF
--- a/spec/exclude-swagger/exclude-swagger-resonse-name.spec.ts
+++ b/spec/exclude-swagger/exclude-swagger-resonse-name.spec.ts
@@ -122,7 +122,7 @@ describe('exclude swagger > defined name', () => {
         expect(routeSet[create].root).toEqual({
             method: 'post',
             path: '/exclude-swagger',
-            operationId: 'reservedCreate',
+            operationId: 'ExcludeSwaggerController_reservedCreate',
             summary: "create one to 'Base' Table",
             description: "Create an entity in 'Base' Table",
             parameters: [],

--- a/spec/exclude-swagger/exclude-swagger.spec.ts
+++ b/spec/exclude-swagger/exclude-swagger.spec.ts
@@ -93,7 +93,7 @@ describe('exclude swagger by route', () => {
         expect(routeSet[create].root).toEqual({
             method: 'post',
             path: '/exclude-swagger',
-            operationId: 'reservedCreate',
+            operationId: 'ExcludeSwaggerController_reservedCreate',
             summary: "create one to 'Base' Table",
             description: "Create an entity in 'Base' Table",
             parameters: [],

--- a/src/lib/crud.decorator.ts
+++ b/src/lib/crud.decorator.ts
@@ -12,7 +12,7 @@ export const Crud =
         const crudRouteFactory = new CrudRouteFactory(target, options);
         crudRouteFactory.init();
 
-        return class extends target {
+        const ValidatedController = class extends target {
             constructor(...args: any[]) {
                 super(...args);
                 if (!(this.crudService instanceof CrudService)) {
@@ -20,4 +20,6 @@ export const Crud =
                 }
             }
         };
+        Object.defineProperty(ValidatedController, 'name', { value: target.name });
+        return ValidatedController;
     };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #558

operationId in swagger docs does not reflect controller name.
It occurs because decorator returns an anonymous class that extends target controller.

## What is the new behavior?

'name' of the returned class is specified as the original controller name.
operationId in swagger docs is like `Controller_ReservedMethod`

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
