### PR TITLE
feat: only take can be used in cursor pagination, not limit

### DIFF
--- a/spec/pagination/pagination.spec.ts
+++ b/spec/pagination/pagination.spec.ts
@@ -24,11 +24,11 @@ describe('Pagination', () => {
                 PaginationModule({
                     cursor: {
                         readMany: { paginationType: 'cursor', numberOfTake: defaultLimit },
-                        search: { paginationType: 'cursor', limitOfTake: defaultLimit },
+                        search: { paginationType: 'cursor', limitOfTake: totalCount },
                     },
                     offset: {
                         readMany: { paginationType: 'offset', numberOfTake: defaultLimit },
-                        search: { paginationType: 'offset', limitOfTake: defaultLimit },
+                        search: { paginationType: 'offset', limitOfTake: totalCount },
                     },
                 }),
             ],
@@ -219,10 +219,10 @@ describe('Pagination', () => {
             expect(metadata.total).toEqual(1);
         });
 
-        it('should return next 20 entities after cursor with order', async () => {
+        it('should return next entities after cursor with order', async () => {
             const { body: firstResponseBody } = await request(app.getHttpServer())
                 .post(`/${PaginationType.CURSOR}/search`)
-                .send({ order: { type: 'ASC' }, limit: 50 })
+                .send({ order: { type: 'ASC', id: 'ASC' }, take: 50 })
                 .expect(HttpStatus.OK);
 
             const { body: nextResponseBody } = await request(app.getHttpServer())
@@ -234,10 +234,10 @@ describe('Pagination', () => {
 
             expect(firstResponseBody.metadata.nextCursor).not.toEqual(nextResponseBody.metadata.nextCursor);
 
-            expect(nextResponseBody.data).toHaveLength(defaultLimit);
+            expect(nextResponseBody.data).toHaveLength(50);
             expect(nextResponseBody.metadata).toEqual({
                 nextCursor: expect.any(String),
-                limit: defaultLimit,
+                limit: 50,
                 total: totalCount,
             });
 
@@ -540,7 +540,7 @@ describe('Pagination', () => {
         it('should return next page from offset with order', async () => {
             const { body: firstResponseBody } = await request(app.getHttpServer())
                 .post(`/${PaginationType.OFFSET}/search`)
-                .send({ order: { type: 'ASC' }, offset: 30 })
+                .send({ order: { type: 'ASC', id: 'ASC' }, offset: 30 })
                 .expect(HttpStatus.OK);
 
             const { body: nextResponseBody } = await request(app.getHttpServer())

--- a/spec/search/search-cursor-pagination.spec.ts
+++ b/spec/search/search-cursor-pagination.spec.ts
@@ -84,7 +84,6 @@ describe('Search Cursor Pagination', () => {
             ],
             order: { col1: 'DESC' },
             take: 10,
-            withDeleted: false,
         });
 
         const { body: secondResponse } = await request(app.getHttpServer())
@@ -109,7 +108,6 @@ describe('Search Cursor Pagination', () => {
         expect(nextLastEntity).toEqual({ col1: 'col1_1' });
         expect(PaginationHelper.deserialize(nextPreCondition.where as string)).toEqual({
             ...searchRequestBody,
-            withDeleted: false,
         });
     });
 
@@ -160,7 +158,6 @@ describe('Search Cursor Pagination', () => {
             ],
             order: { col1: 'DESC' },
             take: 10,
-            withDeleted: false,
         });
 
         const { body: secondResponse } = await request(app.getHttpServer())
@@ -185,7 +182,6 @@ describe('Search Cursor Pagination', () => {
         expect(nextLastEntity).toEqual({ col1: 'col1_1' });
         expect(PaginationHelper.deserialize(nextPreCondition.where as string)).toEqual({
             ...searchRequestBody,
-            withDeleted: false,
         });
     });
 

--- a/src/lib/abstract/abstract.pagination.ts
+++ b/src/lib/abstract/abstract.pagination.ts
@@ -27,11 +27,16 @@ export abstract class AbstractPaginationRequest {
     @IsOptional()
     query?: string;
 
-    /**
-     * Check if the request is requesting the next page.
-     */
-    isNextPage(): this is { query: string } {
+    hasQuery(): this is { query: string } {
         return this.query != null;
+    }
+
+    isOffsetType(): this is { type: PaginationType.OFFSET } {
+        return this.type === PaginationType.OFFSET;
+    }
+
+    isCursorType(): this is { type: PaginationType.CURSOR } {
+        return this.type === PaginationType.CURSOR;
     }
 
     setWhere(where: string | undefined): void {

--- a/src/lib/abstract/abstract.pagination.ts
+++ b/src/lib/abstract/abstract.pagination.ts
@@ -25,7 +25,14 @@ export abstract class AbstractPaginationRequest {
     @Expose({ name: 'nextCursor' })
     @IsString()
     @IsOptional()
-    query: string;
+    query?: string;
+
+    /**
+     * Check if the request is requesting the next page.
+     */
+    isNextPage(): this is { query: string } {
+        return this.query != null;
+    }
 
     setWhere(where: string | undefined): void {
         if (!where) {

--- a/src/lib/dto/request-search.dto.ts
+++ b/src/lib/dto/request-search.dto.ts
@@ -5,7 +5,7 @@ import { QueryFilter, operators } from '../interface/query-operation.interface';
 
 export class RequestSearchDto<T> {
     @ApiPropertyOptional({ description: 'select fields', isArray: true, type: String })
-    select?: Array<keyof Partial<T>>;
+    readonly select?: Array<keyof Partial<T>>;
 
     @ApiPropertyOptional({
         description: 'where conditions',
@@ -29,19 +29,19 @@ export class RequestSearchDto<T> {
             },
         },
     })
-    where?: Array<QueryFilter<T>>;
+    readonly where?: Array<QueryFilter<T>>;
 
     @ApiPropertyOptional({ description: 'order' })
-    order?: {
+    readonly order?: {
         [key in keyof Partial<T>]: Sort | `${Sort}`;
     };
 
     @ApiPropertyOptional({ description: 'withDeleted', type: Boolean })
-    withDeleted?: boolean;
+    readonly withDeleted?: boolean;
 
     @ApiPropertyOptional({ description: 'take', type: Number, example: 20 })
-    take?: number;
+    readonly take?: number;
 
     @ApiPropertyOptional({ description: 'Use to search the next page', type: String })
-    nextCursor?: string;
+    readonly nextCursor?: string;
 }

--- a/src/lib/interceptor/read-many-request.interceptor.ts
+++ b/src/lib/interceptor/read-many-request.interceptor.ts
@@ -41,7 +41,7 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
             const pagination = PaginationHelper.getPaginationRequest(paginationType, req.query);
 
             const query = await (async () => {
-                if (PaginationHelper.isNextPage(pagination)) {
+                if (pagination.isNextPage()) {
                     const isQueryValid = pagination.setQuery(pagination.query);
                     if (isQueryValid) {
                         return {};

--- a/src/lib/interceptor/search-request.interceptor.spec.ts
+++ b/src/lib/interceptor/search-request.interceptor.spec.ts
@@ -66,8 +66,6 @@ describe('SearchRequestInterceptor', () => {
         it('return search request dto when input is valid', async () => {
             expect(await interceptor.validateBody({ select: ['col1', 'col2'] })).toEqual({
                 select: ['col1', 'col2'],
-                take: 20,
-                withDeleted: false,
             });
         });
 
@@ -96,8 +94,6 @@ describe('SearchRequestInterceptor', () => {
                         }),
                     ).toEqual({
                         where: [{ col3: { operator: 'BETWEEN', operand: [0, 5] } }],
-                        take: 20,
-                        withDeleted: false,
                     });
                 });
 
@@ -108,8 +104,6 @@ describe('SearchRequestInterceptor', () => {
                         }),
                     ).toEqual({
                         where: [{ col4: { operator: 'BETWEEN', operand: ['2000-01-01', '2000-02-01'] } }],
-                        take: 20,
-                        withDeleted: false,
                     });
                 });
             });
@@ -120,16 +114,12 @@ describe('SearchRequestInterceptor', () => {
                     }),
                 ).toEqual({
                     where: [{ col3: { operator: 'IN', operand: [0, 1, 2] } }],
-                    take: 20,
-                    withDeleted: false,
                 });
             });
 
             it('NULL', async () => {
                 expect(await interceptor.validateBody({ where: [{ col3: { operator: 'NULL' } }] })).toEqual({
                     where: [{ col3: { operator: 'NULL' } }],
-                    take: 20,
-                    withDeleted: false,
                 });
             });
 
@@ -140,8 +130,6 @@ describe('SearchRequestInterceptor', () => {
                     }),
                 ).toEqual({
                     where: [{ col2: { operator: '=', operand: 7 }, col3: { operator: '>', operand: 3 } }],
-                    take: 20,
-                    withDeleted: false,
                 });
             });
 
@@ -151,9 +139,7 @@ describe('SearchRequestInterceptor', () => {
                         where: [{ col2: { operator: '=', operand: 7, not: false }, col3: { operator: '>', operand: 3, not: true } }],
                     }),
                 ).toEqual({
-                    take: 20,
                     where: [{ col2: { not: false, operand: 7, operator: '=' }, col3: { not: true, operand: 3, operator: '>' } }],
-                    withDeleted: false,
                 });
             });
         });
@@ -261,8 +247,6 @@ describe('SearchRequestInterceptor', () => {
         it('return search request dto when input is valid', async () => {
             expect(await interceptor.validateBody({ order: { col2: Sort.ASC, col3: Sort.DESC } })).toEqual({
                 order: { col2: Sort.ASC, col3: Sort.DESC },
-                take: 20,
-                withDeleted: false,
             });
         });
 
@@ -290,7 +274,7 @@ describe('SearchRequestInterceptor', () => {
     describe('body.withDeleted', () => {
         describe('return search request dto when input is valid', () => {
             test.each([true, false])('withDeleted(%p)', async (withDeleted) => {
-                expect(await interceptor.validateBody({ withDeleted })).toEqual({ withDeleted, take: 20 });
+                expect(await interceptor.validateBody({ withDeleted })).toEqual({ withDeleted });
             });
         });
 
@@ -306,7 +290,7 @@ describe('SearchRequestInterceptor', () => {
     describe('body.take', () => {
         describe('return search request dto when input is valid', () => {
             test.each([1, 20, 100_000])('take(%p)', async (take) => {
-                expect(await interceptor.validateBody({ take })).toEqual({ take, withDeleted: false });
+                expect(await interceptor.validateBody({ take })).toEqual({ take });
             });
         });
 

--- a/src/lib/interceptor/search-request.interceptor.ts
+++ b/src/lib/interceptor/search-request.interceptor.ts
@@ -91,7 +91,7 @@ export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption
                 .setExcludeColumn(searchOptions.exclude)
                 .setWhere(where)
                 .setTake(numberOfTake)
-                .setSort(CRUD_POLICY[method].default.sort)
+                .setSort(sort)
                 .setOrder(order as FindOptionsOrder<typeof crudOptions.entity>)
                 .setWithDeleted(withDeleted)
                 .setRelations(this.getRelations(customSearchRequestOptions))

--- a/src/lib/interceptor/search-request.interceptor.ts
+++ b/src/lib/interceptor/search-request.interceptor.ts
@@ -47,10 +47,9 @@ export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption
             }
             const paginationType = (searchOptions.paginationType ?? CRUD_POLICY[method].default.paginationType) as PaginationType;
             const pagination = PaginationHelper.getPaginationRequest(paginationType, req.body);
-            const isNextPage = PaginationHelper.isNextPage(pagination);
 
             const requestSearchDto = await (async () => {
-                if (isNextPage) {
+                if (pagination.isNextPage()) {
                     const isQueryValid = pagination.setQuery(pagination.query);
                     if (isQueryValid) {
                         return PaginationHelper.deserialize<RequestSearchDto<EntityType>>(pagination.where);

--- a/src/lib/provider/pagination.helper.ts
+++ b/src/lib/provider/pagination.helper.ts
@@ -41,14 +41,4 @@ export class PaginationHelper {
 
         return transformed;
     }
-
-    /**
-     * [EN] Check if the request is requesting the next page.
-     * [KR] Request 요청이 다음 페이지를 요청하는지 확인합니다.
-     * @param paginationRequest
-     * @returns boolean
-     */
-    static isNextPage(paginationRequest: PaginationRequest): boolean {
-        return paginationRequest.query != null;
-    }
 }

--- a/src/lib/request/read-many.request.ts
+++ b/src/lib/request/read-many.request.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
 import { CRUD_POLICY } from '../crud.policy';
-import { Method, PaginationType } from '../interface';
+import { Method } from '../interface';
 import { PaginationHelper } from '../provider';
 
 import type { PaginationRequest, PaginationResponse, Sort } from '../interface';
@@ -124,12 +124,12 @@ export class CrudReadManyRequest<T> {
     }
 
     generate(): this {
-        if (this.pagination.type === PaginationType.OFFSET && Number.isFinite(this.pagination.offset)) {
+        if (this.pagination.isOffsetType() && Number.isFinite(this.pagination.offset)) {
             this._findOptions.where = this._deserialize(this);
             this._findOptions.skip = this.pagination.offset;
         }
 
-        if (this.pagination.type === PaginationType.CURSOR && this.pagination.nextCursor) {
+        if (this.pagination.isCursorType() && this.pagination.nextCursor) {
             this._findOptions.where = this._deserialize(this);
         }
 
@@ -146,7 +146,7 @@ export class CrudReadManyRequest<T> {
         const orderKeys = Object.keys(this._findOptions.order);
         const nextCursor = PaginationHelper.serialize(_.pick(data.at(-1), orderKeys) as FindOptionsWhere<T>);
 
-        if (this.pagination.type === PaginationType.OFFSET) {
+        if (this.pagination.isOffsetType()) {
             return {
                 data,
                 metadata: this.pagination.metadata(take, dataLength, total, nextCursor),

--- a/src/lib/request/read-many.request.ts
+++ b/src/lib/request/read-many.request.ts
@@ -105,12 +105,10 @@ export class CrudReadManyRequest<T> {
 
     setSort(sort: Sort): this {
         this._sort = sort;
-        this._findOptions.order = this.paginationKeys.reduce((order, paginationKey) => ({ ...order, [paginationKey]: sort }), {});
         return this;
     }
 
-    setOrder(order: FindOptionsOrder<T>, sort: Sort): this {
-        this._sort = sort;
+    setOrder(order: FindOptionsOrder<T>): this {
         this._findOptions.order = order;
         return this;
     }
@@ -126,14 +124,9 @@ export class CrudReadManyRequest<T> {
     }
 
     generate(): this {
-        if (this.pagination.type === PaginationType.OFFSET) {
-            if (this.pagination.limit != null) {
-                this._findOptions.take = this.pagination.limit;
-            }
-            if (Number.isFinite(this.pagination.offset)) {
-                this._findOptions.where = this._deserialize(this);
-                this._findOptions.skip = this.pagination.offset;
-            }
+        if (this.pagination.type === PaginationType.OFFSET && Number.isFinite(this.pagination.offset)) {
+            this._findOptions.where = this._deserialize(this);
+            this._findOptions.skip = this.pagination.offset;
         }
 
         if (this.pagination.type === PaginationType.CURSOR && this.pagination.nextCursor) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In cursor pagination, both ‘limit’ and ‘offset’ can be used.

Issue Number: #571 

## What is the new behavior?

In cursor pagination, only ‘offset’ can be used.
In offset pagination, only ‘limit’ can be used.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Additionally, I refactored logic for setting search options
- Properties of `RequestSearchDto` is now readonly, so that preventing modifications(It only represents user input of request body)
  - only the options specified in the request body are serialized in query(nextCursor).
- In `ReadManyRequest`, `setSort` and `setOrder` only set values. Calculated sort and order values are passed by the caller.
- The logic for calculating `takeOfNumber` is consolidated in the interceptor.
- The utility method `isNextPage` is now a method of the pagination.
