### PR TITLE
feat: only take can be used in cursor pagination, not limit

### DIFF
--- a/spec/pagination/pagination.spec.ts
+++ b/spec/pagination/pagination.spec.ts
@@ -24,11 +24,11 @@ describe('Pagination', () => {
                 PaginationModule({
                     cursor: {
                         readMany: { paginationType: 'cursor', numberOfTake: defaultLimit },
-                        search: { paginationType: 'cursor', limitOfTake: defaultLimit },
+                        search: { paginationType: 'cursor', limitOfTake: totalCount },
                     },
                     offset: {
                         readMany: { paginationType: 'offset', numberOfTake: defaultLimit },
-                        search: { paginationType: 'offset', limitOfTake: defaultLimit },
+                        search: { paginationType: 'offset', limitOfTake: totalCount },
                     },
                 }),
             ],
@@ -219,10 +219,10 @@ describe('Pagination', () => {
             expect(metadata.total).toEqual(1);
         });
 
-        it('should return next 20 entities after cursor with order', async () => {
+        it('should return next entities after cursor with order', async () => {
             const { body: firstResponseBody } = await request(app.getHttpServer())
                 .post(`/${PaginationType.CURSOR}/search`)
-                .send({ order: { type: 'ASC' }, limit: 50 })
+                .send({ order: { type: 'ASC', id: 'ASC' }, take: 50 })
                 .expect(HttpStatus.OK);
 
             const { body: nextResponseBody } = await request(app.getHttpServer())
@@ -234,10 +234,10 @@ describe('Pagination', () => {
 
             expect(firstResponseBody.metadata.nextCursor).not.toEqual(nextResponseBody.metadata.nextCursor);
 
-            expect(nextResponseBody.data).toHaveLength(defaultLimit);
+            expect(nextResponseBody.data).toHaveLength(50);
             expect(nextResponseBody.metadata).toEqual({
                 nextCursor: expect.any(String),
-                limit: defaultLimit,
+                limit: 50,
                 total: totalCount,
             });
 
@@ -540,7 +540,7 @@ describe('Pagination', () => {
         it('should return next page from offset with order', async () => {
             const { body: firstResponseBody } = await request(app.getHttpServer())
                 .post(`/${PaginationType.OFFSET}/search`)
-                .send({ order: { type: 'ASC' }, offset: 30 })
+                .send({ order: { type: 'ASC', id: 'ASC' }, offset: 30 })
                 .expect(HttpStatus.OK);
 
             const { body: nextResponseBody } = await request(app.getHttpServer())

--- a/src/lib/interceptor/read-many-request.interceptor.ts
+++ b/src/lib/interceptor/read-many-request.interceptor.ts
@@ -52,6 +52,9 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
                 return query;
             })();
             const paginationKeys = readManyOptions.paginationKeys ?? factoryOption.primaryKeys.map(({ name }) => name);
+            const numberOfTake =
+                (pagination.type === 'cursor' ? readManyOptions.numberOfTake : pagination.limit ?? readManyOptions.numberOfTake) ??
+                CRUD_POLICY[method].default.numberOfTake;
             const crudReadManyRequest: CrudReadManyRequest<typeof crudOptions.entity> = new CrudReadManyRequest<typeof crudOptions.entity>()
                 .setPaginationKeys(paginationKeys)
                 .setExcludeColumn(readManyOptions.exclude)
@@ -62,7 +65,7 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
                         : crudOptions.routes?.[method]?.softDelete ?? CRUD_POLICY[method].default.softDeleted,
                 )
                 .setWhere(query)
-                .setTake(readManyOptions.numberOfTake ?? CRUD_POLICY[method].default.numberOfTake)
+                .setTake(numberOfTake)
                 .setSort(readManyOptions.sort ? Sort[readManyOptions.sort] : CRUD_POLICY[method].default.sort)
                 .setRelations(this.getRelations(customReadManyRequestOptions))
                 .setDeserialize(this.deserialize)

--- a/src/lib/interceptor/search-request.interceptor.spec.ts
+++ b/src/lib/interceptor/search-request.interceptor.spec.ts
@@ -66,7 +66,6 @@ describe('SearchRequestInterceptor', () => {
         it('return search request dto when input is valid', async () => {
             expect(await interceptor.validateBody({ select: ['col1', 'col2'] })).toEqual({
                 select: ['col1', 'col2'],
-                take: 20,
                 withDeleted: false,
             });
         });
@@ -96,7 +95,6 @@ describe('SearchRequestInterceptor', () => {
                         }),
                     ).toEqual({
                         where: [{ col3: { operator: 'BETWEEN', operand: [0, 5] } }],
-                        take: 20,
                         withDeleted: false,
                     });
                 });
@@ -108,7 +106,6 @@ describe('SearchRequestInterceptor', () => {
                         }),
                     ).toEqual({
                         where: [{ col4: { operator: 'BETWEEN', operand: ['2000-01-01', '2000-02-01'] } }],
-                        take: 20,
                         withDeleted: false,
                     });
                 });
@@ -120,7 +117,6 @@ describe('SearchRequestInterceptor', () => {
                     }),
                 ).toEqual({
                     where: [{ col3: { operator: 'IN', operand: [0, 1, 2] } }],
-                    take: 20,
                     withDeleted: false,
                 });
             });
@@ -128,7 +124,6 @@ describe('SearchRequestInterceptor', () => {
             it('NULL', async () => {
                 expect(await interceptor.validateBody({ where: [{ col3: { operator: 'NULL' } }] })).toEqual({
                     where: [{ col3: { operator: 'NULL' } }],
-                    take: 20,
                     withDeleted: false,
                 });
             });
@@ -140,7 +135,6 @@ describe('SearchRequestInterceptor', () => {
                     }),
                 ).toEqual({
                     where: [{ col2: { operator: '=', operand: 7 }, col3: { operator: '>', operand: 3 } }],
-                    take: 20,
                     withDeleted: false,
                 });
             });
@@ -151,7 +145,6 @@ describe('SearchRequestInterceptor', () => {
                         where: [{ col2: { operator: '=', operand: 7, not: false }, col3: { operator: '>', operand: 3, not: true } }],
                     }),
                 ).toEqual({
-                    take: 20,
                     where: [{ col2: { not: false, operand: 7, operator: '=' }, col3: { not: true, operand: 3, operator: '>' } }],
                     withDeleted: false,
                 });
@@ -261,7 +254,6 @@ describe('SearchRequestInterceptor', () => {
         it('return search request dto when input is valid', async () => {
             expect(await interceptor.validateBody({ order: { col2: Sort.ASC, col3: Sort.DESC } })).toEqual({
                 order: { col2: Sort.ASC, col3: Sort.DESC },
-                take: 20,
                 withDeleted: false,
             });
         });
@@ -290,7 +282,7 @@ describe('SearchRequestInterceptor', () => {
     describe('body.withDeleted', () => {
         describe('return search request dto when input is valid', () => {
             test.each([true, false])('withDeleted(%p)', async (withDeleted) => {
-                expect(await interceptor.validateBody({ withDeleted })).toEqual({ withDeleted, take: 20 });
+                expect(await interceptor.validateBody({ withDeleted })).toEqual({ withDeleted });
             });
         });
 

--- a/src/lib/interceptor/search-request.interceptor.ts
+++ b/src/lib/interceptor/search-request.interceptor.ts
@@ -78,6 +78,10 @@ export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption
                     : [];
 
             const paginationKeys = searchOptions.paginationKeys ?? factoryOption.primaryKeys.map(({ name }) => name);
+            const numberOfTake =
+                (pagination.type === 'cursor' ? requestSearchDto.take : pagination.limit) ??
+                searchOptions.numberOfTake ??
+                CRUD_POLICY[method].default.numberOfTake;
             requestSearchDto.order ??= paginationKeys.reduce((acc, key) => ({ ...acc, [key]: CRUD_POLICY[method].default.sort }), {});
 
             const crudReadManyRequest: CrudReadManyRequest<typeof crudOptions.entity> = new CrudReadManyRequest<typeof crudOptions.entity>()
@@ -86,7 +90,7 @@ export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption
                 .setSelectColumn(requestSearchDto.select)
                 .setExcludeColumn(searchOptions.exclude)
                 .setWhere(where)
-                .setTake(requestSearchDto.take ?? CRUD_POLICY[method].default.numberOfTake)
+                .setTake(numberOfTake)
                 .setOrder(requestSearchDto.order as FindOptionsOrder<typeof crudOptions.entity>, CRUD_POLICY[method].default.sort)
                 .setWithDeleted(
                     requestSearchDto.withDeleted ?? crudOptions.routes?.[method]?.softDelete ?? CRUD_POLICY[method].default.softDeleted,
@@ -131,11 +135,6 @@ export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption
             if ('take' in requestSearchDto) {
                 this.validateTake(requestSearchDto.take, searchOptions.limitOfTake);
             }
-
-            requestSearchDto.take =
-                'take' in requestSearchDto
-                    ? this.validateTake(requestSearchDto.take, searchOptions.limitOfTake)
-                    : searchOptions.numberOfTake ?? CRUD_POLICY[method].default.numberOfTake;
 
             return requestSearchDto;
         }

--- a/src/lib/request/read-many.request.ts
+++ b/src/lib/request/read-many.request.ts
@@ -126,14 +126,9 @@ export class CrudReadManyRequest<T> {
     }
 
     generate(): this {
-        if (this.pagination.type === PaginationType.OFFSET) {
-            if (this.pagination.limit != null) {
-                this._findOptions.take = this.pagination.limit;
-            }
-            if (Number.isFinite(this.pagination.offset)) {
-                this._findOptions.where = this._deserialize(this);
-                this._findOptions.skip = this.pagination.offset;
-            }
+        if (this.pagination.type === PaginationType.OFFSET && Number.isFinite(this.pagination.offset)) {
+            this._findOptions.where = this._deserialize(this);
+            this._findOptions.skip = this.pagination.offset;
         }
 
         if (this.pagination.type === PaginationType.CURSOR && this.pagination.nextCursor) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In cursor pagination, both ‘limit’ and ‘offset’ can be used.

Issue Number: #571 

## What is the new behavior?

In cursor pagination, only ‘offset’ can be used.
In offset pagination, only ‘limit’ can be used.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
separated PR from #579 