### PR TITLE
refactor:  improve the logic for setting options in readMany and search

### DIFF
--- a/spec/search/search-cursor-pagination.spec.ts
+++ b/spec/search/search-cursor-pagination.spec.ts
@@ -84,7 +84,6 @@ describe('Search Cursor Pagination', () => {
             ],
             order: { col1: 'DESC' },
             take: 10,
-            withDeleted: false,
         });
 
         const { body: secondResponse } = await request(app.getHttpServer())
@@ -109,7 +108,6 @@ describe('Search Cursor Pagination', () => {
         expect(nextLastEntity).toEqual({ col1: 'col1_1' });
         expect(PaginationHelper.deserialize(nextPreCondition.where as string)).toEqual({
             ...searchRequestBody,
-            withDeleted: false,
         });
     });
 
@@ -160,7 +158,6 @@ describe('Search Cursor Pagination', () => {
             ],
             order: { col1: 'DESC' },
             take: 10,
-            withDeleted: false,
         });
 
         const { body: secondResponse } = await request(app.getHttpServer())
@@ -185,7 +182,6 @@ describe('Search Cursor Pagination', () => {
         expect(nextLastEntity).toEqual({ col1: 'col1_1' });
         expect(PaginationHelper.deserialize(nextPreCondition.where as string)).toEqual({
             ...searchRequestBody,
-            withDeleted: false,
         });
     });
 

--- a/src/lib/interceptor/read-many-request.interceptor.ts
+++ b/src/lib/interceptor/read-many-request.interceptor.ts
@@ -60,7 +60,6 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
                 (pagination.type === 'cursor' ? readManyOptions.numberOfTake : pagination.limit ?? readManyOptions.numberOfTake) ??
                 CRUD_POLICY[method].default.numberOfTake;
             const sort = readManyOptions.sort ? Sort[readManyOptions.sort] : CRUD_POLICY[method].default.sort;
-            const order = paginationKeys.reduce((order, paginationKey) => ({ ...order, [paginationKey]: sort }), {});
 
             const crudReadManyRequest: CrudReadManyRequest<typeof crudOptions.entity> = new CrudReadManyRequest<typeof crudOptions.entity>()
                 .setPaginationKeys(paginationKeys)
@@ -70,7 +69,6 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
                 .setWhere(query)
                 .setTake(numberOfTake)
                 .setSort(sort)
-                .setOrder(order)
                 .setRelations(this.getRelations(customReadManyRequestOptions))
                 .setDeserialize(this.deserialize)
                 .generate();

--- a/src/lib/interceptor/read-many-request.interceptor.ts
+++ b/src/lib/interceptor/read-many-request.interceptor.ts
@@ -59,6 +59,9 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
             const numberOfTake =
                 (pagination.type === 'cursor' ? readManyOptions.numberOfTake : pagination.limit ?? readManyOptions.numberOfTake) ??
                 CRUD_POLICY[method].default.numberOfTake;
+            const sort = readManyOptions.sort ? Sort[readManyOptions.sort] : CRUD_POLICY[method].default.sort;
+            const order = paginationKeys.reduce((order, paginationKey) => ({ ...order, [paginationKey]: sort }), {});
+
             const crudReadManyRequest: CrudReadManyRequest<typeof crudOptions.entity> = new CrudReadManyRequest<typeof crudOptions.entity>()
                 .setPaginationKeys(paginationKeys)
                 .setExcludeColumn(readManyOptions.exclude)
@@ -66,7 +69,8 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
                 .setWithDeleted(withDeleted)
                 .setWhere(query)
                 .setTake(numberOfTake)
-                .setSort(readManyOptions.sort ? Sort[readManyOptions.sort] : CRUD_POLICY[method].default.sort)
+                .setSort(sort)
+                .setOrder(order)
                 .setRelations(this.getRelations(customReadManyRequestOptions))
                 .setDeserialize(this.deserialize)
                 .generate();

--- a/src/lib/interceptor/read-many-request.interceptor.ts
+++ b/src/lib/interceptor/read-many-request.interceptor.ts
@@ -40,6 +40,10 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
 
             const pagination = PaginationHelper.getPaginationRequest(paginationType, req.query);
 
+            const withDeleted = _.isBoolean(customReadManyRequestOptions?.softDeleted)
+                ? customReadManyRequestOptions.softDeleted
+                : crudOptions.routes?.[method]?.softDelete ?? CRUD_POLICY[method].default.softDeleted;
+
             const query = await (async () => {
                 if (PaginationHelper.isNextPage(pagination)) {
                     const isQueryValid = pagination.setQuery(pagination.query);
@@ -59,11 +63,7 @@ export function ReadManyRequestInterceptor(crudOptions: CrudOptions, factoryOpti
                 .setPaginationKeys(paginationKeys)
                 .setExcludeColumn(readManyOptions.exclude)
                 .setPagination(pagination)
-                .setWithDeleted(
-                    _.isBoolean(customReadManyRequestOptions?.softDeleted)
-                        ? customReadManyRequestOptions.softDeleted
-                        : crudOptions.routes?.[method]?.softDelete ?? CRUD_POLICY[method].default.softDeleted,
-                )
+                .setWithDeleted(withDeleted)
                 .setWhere(query)
                 .setTake(numberOfTake)
                 .setSort(readManyOptions.sort ? Sort[readManyOptions.sort] : CRUD_POLICY[method].default.sort)

--- a/src/lib/interceptor/search-request.interceptor.spec.ts
+++ b/src/lib/interceptor/search-request.interceptor.spec.ts
@@ -66,7 +66,6 @@ describe('SearchRequestInterceptor', () => {
         it('return search request dto when input is valid', async () => {
             expect(await interceptor.validateBody({ select: ['col1', 'col2'] })).toEqual({
                 select: ['col1', 'col2'],
-                withDeleted: false,
             });
         });
 
@@ -95,7 +94,6 @@ describe('SearchRequestInterceptor', () => {
                         }),
                     ).toEqual({
                         where: [{ col3: { operator: 'BETWEEN', operand: [0, 5] } }],
-                        withDeleted: false,
                     });
                 });
 
@@ -106,7 +104,6 @@ describe('SearchRequestInterceptor', () => {
                         }),
                     ).toEqual({
                         where: [{ col4: { operator: 'BETWEEN', operand: ['2000-01-01', '2000-02-01'] } }],
-                        withDeleted: false,
                     });
                 });
             });
@@ -117,14 +114,12 @@ describe('SearchRequestInterceptor', () => {
                     }),
                 ).toEqual({
                     where: [{ col3: { operator: 'IN', operand: [0, 1, 2] } }],
-                    withDeleted: false,
                 });
             });
 
             it('NULL', async () => {
                 expect(await interceptor.validateBody({ where: [{ col3: { operator: 'NULL' } }] })).toEqual({
                     where: [{ col3: { operator: 'NULL' } }],
-                    withDeleted: false,
                 });
             });
 
@@ -135,7 +130,6 @@ describe('SearchRequestInterceptor', () => {
                     }),
                 ).toEqual({
                     where: [{ col2: { operator: '=', operand: 7 }, col3: { operator: '>', operand: 3 } }],
-                    withDeleted: false,
                 });
             });
 
@@ -146,7 +140,6 @@ describe('SearchRequestInterceptor', () => {
                     }),
                 ).toEqual({
                     where: [{ col2: { not: false, operand: 7, operator: '=' }, col3: { not: true, operand: 3, operator: '>' } }],
-                    withDeleted: false,
                 });
             });
         });
@@ -254,7 +247,6 @@ describe('SearchRequestInterceptor', () => {
         it('return search request dto when input is valid', async () => {
             expect(await interceptor.validateBody({ order: { col2: Sort.ASC, col3: Sort.DESC } })).toEqual({
                 order: { col2: Sort.ASC, col3: Sort.DESC },
-                withDeleted: false,
             });
         });
 
@@ -298,7 +290,7 @@ describe('SearchRequestInterceptor', () => {
     describe('body.take', () => {
         describe('return search request dto when input is valid', () => {
             test.each([1, 20, 100_000])('take(%p)', async (take) => {
-                expect(await interceptor.validateBody({ take })).toEqual({ take, withDeleted: false });
+                expect(await interceptor.validateBody({ take })).toEqual({ take });
             });
         });
 

--- a/src/lib/interceptor/search-request.interceptor.ts
+++ b/src/lib/interceptor/search-request.interceptor.ts
@@ -84,6 +84,9 @@ export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption
                 CRUD_POLICY[method].default.numberOfTake;
             requestSearchDto.order ??= paginationKeys.reduce((acc, key) => ({ ...acc, [key]: CRUD_POLICY[method].default.sort }), {});
 
+            const withDeleted =
+                requestSearchDto.withDeleted ?? crudOptions.routes?.[method]?.softDelete ?? CRUD_POLICY[method].default.softDeleted;
+
             const crudReadManyRequest: CrudReadManyRequest<typeof crudOptions.entity> = new CrudReadManyRequest<typeof crudOptions.entity>()
                 .setPaginationKeys(paginationKeys)
                 .setPagination(pagination)
@@ -92,9 +95,7 @@ export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption
                 .setWhere(where)
                 .setTake(numberOfTake)
                 .setOrder(requestSearchDto.order as FindOptionsOrder<typeof crudOptions.entity>, CRUD_POLICY[method].default.sort)
-                .setWithDeleted(
-                    requestSearchDto.withDeleted ?? crudOptions.routes?.[method]?.softDelete ?? CRUD_POLICY[method].default.softDeleted,
-                )
+                .setWithDeleted(withDeleted)
                 .setRelations(this.getRelations(customSearchRequestOptions))
                 .setDeserialize(this.deserialize)
                 .generate();
@@ -128,8 +129,6 @@ export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption
 
             if ('withDeleted' in requestSearchDto) {
                 this.validateWithDeleted(requestSearchDto.withDeleted);
-            } else {
-                requestSearchDto.withDeleted = searchOptions.softDelete ?? CRUD_POLICY[method].default.softDeleted;
             }
 
             if ('take' in requestSearchDto) {

--- a/src/lib/interceptor/search-request.interceptor.ts
+++ b/src/lib/interceptor/search-request.interceptor.ts
@@ -20,7 +20,7 @@ import type { OperatorUnion } from '../interface/query-operation.interface';
 import type { CallHandler, ExecutionContext, NestInterceptor } from '@nestjs/common';
 import type { Request } from 'express';
 import type { Observable } from 'rxjs';
-import type { FindOptionsOrder, FindOptionsWhere, FindOperator } from 'typeorm';
+import type { FindOptionsWhere, FindOperator } from 'typeorm';
 
 const method = Method.SEARCH;
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -82,7 +82,8 @@ export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption
                 (pagination.type === 'cursor' ? requestSearchDto.take : pagination.limit) ??
                 searchOptions.numberOfTake ??
                 CRUD_POLICY[method].default.numberOfTake;
-            requestSearchDto.order ??= paginationKeys.reduce((acc, key) => ({ ...acc, [key]: CRUD_POLICY[method].default.sort }), {});
+            const sort = CRUD_POLICY[method].default.sort;
+            const order = requestSearchDto.order ?? paginationKeys.reduce((acc, key) => ({ ...acc, [key]: sort }), {});
 
             const withDeleted =
                 requestSearchDto.withDeleted ?? crudOptions.routes?.[method]?.softDelete ?? CRUD_POLICY[method].default.softDeleted;
@@ -94,7 +95,8 @@ export function SearchRequestInterceptor(crudOptions: CrudOptions, factoryOption
                 .setExcludeColumn(searchOptions.exclude)
                 .setWhere(where)
                 .setTake(numberOfTake)
-                .setOrder(requestSearchDto.order as FindOptionsOrder<typeof crudOptions.entity>, CRUD_POLICY[method].default.sort)
+                .setSort(sort)
+                .setOrder(order)
                 .setWithDeleted(withDeleted)
                 .setRelations(this.getRelations(customSearchRequestOptions))
                 .setDeserialize(this.deserialize)

--- a/src/lib/request/read-many.request.ts
+++ b/src/lib/request/read-many.request.ts
@@ -105,6 +105,7 @@ export class CrudReadManyRequest<T> {
 
     setSort(sort: Sort): this {
         this._sort = sort;
+        this._findOptions.order = this.paginationKeys.reduce((order, paginationKey) => ({ ...order, [paginationKey]: sort }), {});
         return this;
     }
 

--- a/src/lib/request/read-many.request.ts
+++ b/src/lib/request/read-many.request.ts
@@ -105,12 +105,10 @@ export class CrudReadManyRequest<T> {
 
     setSort(sort: Sort): this {
         this._sort = sort;
-        this._findOptions.order = this.paginationKeys.reduce((order, paginationKey) => ({ ...order, [paginationKey]: sort }), {});
         return this;
     }
 
-    setOrder(order: FindOptionsOrder<T>, sort: Sort): this {
-        this._sort = sort;
+    setOrder(order: FindOptionsOrder<T>): this {
         this._findOptions.order = order;
         return this;
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [x] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

During the validation stage, `withDeleted` was assigned redundantly with default values, and this was being serialized in the query(nextCursor).
`setSort` and `setOrder` both set the sort and order, making their roles unclear.

## What is the new behavior?

Default value for `withDeleted` is assigned only in the intercept method, and only user input is serialized in the query.
`setSort` and `setOrder` only set values. Calculated sort and order values are passed by the readMany/search interceptor.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

separated PR from #579 